### PR TITLE
初回生成物の自動保存と公開実行を確実化

### DIFF
--- a/.github/workflows/update-calendar.yml
+++ b/.github/workflows/update-calendar.yml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6


### PR DESCRIPTION
## 変更

- 未追跡の`public/`も検出して初回生成物を自動commitする
- 公開ジョブへ15分の上限を設定し、停止状態を防ぐ

## 目的

初回ビルドから生成JSON・ICS・Web UIをmainへ保存し、GitHub Pages公開まで同じワークフローで完結させます。