### PR TITLE
定期イベントを120日分展開して掲載件数を拡張

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,18 @@ jobs:
           cache: pip
       - run: python -m pip install --upgrade pip
       - run: pip install -e '.[dev]'
-      - run: ruff check cast_event_cal tests/test_core.py main_executor.py
-      - run: pytest tests/test_core.py
+      - run: ruff check cast_event_cal scripts tests main_executor.py
+      - run: pytest tests
       - run: python main_executor.py validate
+      - run: python scripts/materialize_events.py
+      - name: Enforce useful event coverage
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          events = json.loads(Path('data/manual_events.json').read_text(encoding='utf-8'))
+          assert len(events) >= 60, f'event coverage too small: {len(events)}'
+          assert len({item['source_id'] for item in events}) == len(events)
+          PY
       - run: python main_executor.py run --strict

--- a/.github/workflows/update-calendar.yml
+++ b/.github/workflows/update-calendar.yml
@@ -9,7 +9,9 @@ on:
     paths:
       - cast_event_cal/**
       - config/**
-      - data/manual_events.json
+      - data/recurring_events.json
+      - data/one_off_events.json
+      - scripts/materialize_events.py
       - main_executor.py
       - requirements.txt
       - pyproject.toml
@@ -38,12 +40,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Materialize recurring events
+        run: python scripts/materialize_events.py
       - name: Build calendar
         env:
           X_BEARER_TOKEN: ${{ secrets.X_BEARER_TOKEN }}
           VRCHAT_AUTH_COOKIE: ${{ secrets.VRCHAT_AUTH_COOKIE }}
         run: python main_executor.py run --strict
-      - name: Validate generated assets
+      - name: Validate generated assets and coverage
         run: |
           grep -q 'VRChat Event Calendar' public/index.html
           grep -q 'BEGIN:VCALENDAR' public/calendar.ics
@@ -51,21 +55,25 @@ jobs:
           import json
           from pathlib import Path
 
+          manual = json.loads(Path('data/manual_events.json').read_text(encoding='utf-8'))
           events = json.loads(Path('public/events.json').read_text(encoding='utf-8'))
           health = json.loads(Path('public/health.json').read_text(encoding='utf-8'))
+          assert len(manual) >= 60, f'event coverage too small: {len(manual)}'
+          assert len({item['source_id'] for item in manual}) == len(manual)
           assert isinstance(events.get('events'), list)
           assert events.get('count') == len(events['events'])
+          assert events.get('count') >= 60
           assert health.get('event_count') == events.get('count')
           assert health.get('status') in {'ok', 'degraded'}
           PY
       - name: Commit generated data
         run: |
-          if [ -z "$(git status --porcelain -- public)" ]; then
+          if [ -z "$(git status --porcelain -- data/manual_events.json public)" ]; then
             echo 'No generated changes'
             exit 0
           fi
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add public
+          git add data/manual_events.json public
           git commit -m 'chore: refresh calendar [skip ci]'
           git push

--- a/README.md
+++ b/README.md
@@ -12,24 +12,38 @@ VRChatイベントの公開情報を定期取得し、出典を保持した正�
 - Xの画面スクレイピングとID・パスワード直書きを廃止
 - X API v2、VRChat Group Calendar、公開ICS、公開JSON、手動JSONを同じ取得層で処理
 - 曖昧な日時を推測で確定せず、明示的な日時だけを採用
+- 公開一次情報で確認した定期イベントを120日先まで開催日単位に展開
 - 出典IDを優先した重複排除と、取得元ごとの失敗隔離
 - `events.json`、`calendar.ics`、`health.json`、Web UIを一度に生成
 - 6時間ごとのデータ生成、生成物のcommit、公開ミラーへの同期
+- 60件未満を失敗させるイベント件数ゲート
 - 公開URLとJSON APIのHTTP 200自己監査
 - Python 3.11〜3.13でCI、設定検証、単体テスト、静的解析
 
 ## データフロー
 
 ```text
-公開JSON / ICS / X API / VRChat Group Calendar / 手動JSON
-  → 取得元ごとに収集・失敗隔離
-  → UTCへ正規化（表示はAsia/Tokyo）
-  → 出典IDまたは主催者・タイトル・日時・会場で同一性判定
-  → 公開期間でフィルタ
+公開一次情報
+  → data/recurring_events.json（定期系列）
+  → data/one_off_events.json（単発開催）
+  → scripts/materialize_events.pyで120日分を日付展開
+  → data/manual_events.json
+  → 取得・UTC正規化・重複排除
   → public/ にJSON / ICS / health / Web UIを生成
   → vrc_cast_event_calenderへ同期
   → GitHub Pages公開とHTTP 200監査
 ```
+
+## 定期イベントの管理
+
+`data/recurring_events.json`には、曜日、開始時刻、終了時刻、タイムゾーン、根拠URLを持つ系列だけを登録します。`scripts/materialize_events.py`が実行時点から過去1日・未来120日の各開催日を生成するため、同じイベントを手作業で毎週追加する必要はありません。
+
+対応する頻度は次のとおりです。
+
+- `weekly`: 複数曜日を指定できる週次開催
+- `monthly_nth_weekday`: 第3日曜などの月次開催
+
+終了時刻を一次情報で確認できないイベントは、推測せず`end_time`を省略します。生成後の`source_id`は系列IDと開催日の組み合わせになり、同一系列の各回を独立した予定としてJSONとICSへ出力します。
 
 ## ローカル実行
 
@@ -38,7 +52,8 @@ python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -e '.[dev]'
 python main_executor.py validate
-python main_executor.py run
+python scripts/materialize_events.py
+python main_executor.py run --strict
 python -m http.server 8000 --directory public
 ```
 
@@ -46,7 +61,7 @@ python -m http.server 8000 --directory public
 
 ## 取得元の追加
 
-`config/sources.yaml`を編集します。
+定期系列は`data/recurring_events.json`、単発予定は`data/one_off_events.json`へ追加します。APIまたはフィードは`config/sources.yaml`へ追加します。
 
 ```yaml
 sources:
@@ -74,6 +89,7 @@ Repository Secretに`VRCHAT_AUTH_COOKIE`を登録し、実在する`group_id`を
 
 ## 出力
 
+- `data/manual_events.json`: 定期系列と単発予定を展開した入力データ
 - `public/events.json`: 正規化イベントAPI
 - `public/calendar.ics`: カレンダー購読用
 - `public/health.json`: 取得元ごとの成功・失敗・件数
@@ -88,9 +104,10 @@ Repository Secretに`VRCHAT_AUTH_COOKIE`を登録し、実在する`group_id`を
 `cast_event_cal/.github/workflows/update-calendar.yml`が次を実行します。
 
 1. 6時間ごと、手動実行、主要設定変更時に起動
-2. 取得・正規化・公開物生成
-3. HTML、JSON、ICS、healthの整合性検証
-4. 差分がある場合だけ`public/`を自動commit・push
+2. 定期系列を120日先まで展開
+3. 取得・正規化・公開物生成
+4. HTML、JSON、ICS、health、最低件数を検証
+5. 差分がある場合だけ`data/manual_events.json`と`public/`を自動commit・push
 
 ### 本番公開
 
@@ -109,6 +126,7 @@ CIは`.github/workflows/ci.yml`でPython 3.11〜3.13を検証します。
 - APIトークン、Cookie、`.env`、ブラウザ認証状態をGitへ追加しない
 - Xのユーザー名・パスワードを使用しない
 - 公開情報のみを対象とし、招待制・非公開イベントを公開イベントと断定しない
+- 開催時刻や終了時刻を推測しない
 - 取得元の利用規約、API上限、削除・中止情報を優先する
 
 ## ライセンス

--- a/data/one_off_events.json
+++ b/data/one_off_events.json
@@ -1,0 +1,37 @@
+[
+  {
+    "source_id": "vrchat-cal_0a0f7c7d-3f18-4fb4-859e-c89a05c31097",
+    "title": "Pyropaw Pyrocon Showcase",
+    "starts_at": "2026-08-15T23:00:00Z",
+    "ends_at": "2026-08-16T03:30:00Z",
+    "organizer": "Pyropaw",
+    "location": "VRChat",
+    "description": "DJ、アート、アニメーション、制作物紹介などを行う公開ショーケースイベント。",
+    "url": "https://vrchat.com/home/group/grp_fdc62cb2-130c-4425-a5b9-95e4efd43d11/calendar/cal_0a0f7c7d-3f18-4fb4-859e-c89a05c31097",
+    "category": "performance",
+    "tags": [
+      "Animation",
+      "Art",
+      "DJ",
+      "Furry",
+      "VRChat"
+    ],
+    "confidence": 1.0
+  },
+  {
+    "source_id": "vrchat-cal_7bf39952-a3b2-45f8-923e-08d8535749b9",
+    "title": "VRTon 2026",
+    "starts_at": "2026-11-06T23:00:00Z",
+    "ends_at": "2026-11-08T03:00:00Z",
+    "organizer": "VRTon",
+    "location": "VRChat",
+    "description": "VRChat公式カレンダーで公開されているVRTon 2026。",
+    "url": "https://vrchat.com/home/group/grp_d66fc7e0-955b-42aa-9abb-372bc72c178f/calendar/cal_7bf39952-a3b2-45f8-923e-08d8535749b9",
+    "category": "convention",
+    "tags": [
+      "VRChat",
+      "VRTon"
+    ],
+    "confidence": 1.0
+  }
+]

--- a/data/recurring_events.json
+++ b/data/recurring_events.json
@@ -1,0 +1,100 @@
+[
+  {
+    "series_id": "vrchat-wednesday-quest-beginners",
+    "title": "水曜Quest初心者の集い",
+    "organizer": "水曜Quest初心者の集い",
+    "location": "VRChat Group Instance",
+    "description": "毎週水曜21時から22時まで開催される、初心者およびQuest・PicoなどAndroid版利用者向けの日本語交流イベント。",
+    "url": "https://vrchat.com/home/group/grp_3e1dd1c4-c555-4477-a39d-96f0bb0469ca/calendar/cal_ffabe2fa-029c-427e-a20e-ec19ebfacb5f",
+    "category": "hangout",
+    "tags": [
+      "VRChat",
+      "Quest",
+      "Pico",
+      "初心者向け",
+      "日本語",
+      "定期開催"
+    ],
+    "schedule": {
+      "frequency": "weekly",
+      "weekdays": [
+        "WE"
+      ],
+      "start_time": "21:00",
+      "end_time": "22:00",
+      "timezone": "Asia/Tokyo"
+    }
+  },
+  {
+    "series_id": "vrchat-yuru-game-meet",
+    "title": "ゆるゲMEET定期開催日",
+    "organizer": "ゆるゲMEET",
+    "location": "VRChat Group Instance",
+    "description": "毎週水曜夜21時開催の、初心者も参加できるゲームワールド集会。",
+    "url": "https://vrchat.com/home/group/grp_34ca87e0-7ab4-4a55-b9aa-5f502ad493d5/calendar/cal_0cfc20f2-aba2-4c15-8628-59212d1dc53f",
+    "category": "game",
+    "tags": [
+      "VRChat",
+      "ゲームワールド",
+      "初心者向け",
+      "日本語",
+      "定期開催"
+    ],
+    "schedule": {
+      "frequency": "weekly",
+      "weekdays": [
+        "WE"
+      ],
+      "start_time": "21:00",
+      "end_time": "22:00",
+      "timezone": "Asia/Tokyo"
+    }
+  },
+  {
+    "series_id": "vrchat-newbie-world-tour",
+    "title": "VRC初心者ワールドツアー",
+    "organizer": "VRC初心者ワールドツアー",
+    "location": "VRChat",
+    "description": "毎週木曜21時開催の初心者向けワールドツアー。終了時刻は一次情報で確認できないため未設定。",
+    "url": "https://vrchat.com/home/launch?worldId=wrld_20a3f7c6-9529-4af3-8bae-f60109a1b6ea",
+    "category": "world_tour",
+    "tags": [
+      "VRChat",
+      "ワールド巡り",
+      "初心者向け",
+      "日本語",
+      "定期開催"
+    ],
+    "schedule": {
+      "frequency": "weekly",
+      "weekdays": [
+        "TH"
+      ],
+      "start_time": "21:00",
+      "timezone": "Asia/Tokyo"
+    }
+  },
+  {
+    "series_id": "vrchat-petting-zoo",
+    "title": "VRCふれあい動物園",
+    "organizer": "VRCふれあい動物園",
+    "location": "VRChat",
+    "description": "毎週金曜22時開園の交流イベント。終了時刻は一次情報で確認できないため未設定。",
+    "url": "https://vrchat.com/home/launch?worldId=wrld_9a1eedbb-34ee-49cd-87da-41e321258fb6",
+    "category": "hangout",
+    "tags": [
+      "VRChat",
+      "交流",
+      "日本語",
+      "定期開催"
+    ],
+    "schedule": {
+      "frequency": "weekly",
+      "weekdays": [
+        "FR"
+      ],
+      "start_time": "22:00",
+      "timezone": "Asia/Tokyo"
+    }
+  }
+]

--- a/scripts/materialize_events.py
+++ b/scripts/materialize_events.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, date, datetime, time, timedelta
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+WEEKDAYS = {"MO": 0, "TU": 1, "WE": 2, "TH": 3, "FR": 4, "SA": 5, "SU": 6}
+
+
+def parse_instant(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def utc_text(value: datetime) -> str:
+    return value.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_clock(value: str) -> time:
+    return time.fromisoformat(value)
+
+
+def event_for_date(template: dict[str, Any], local_day: date) -> dict[str, Any]:
+    schedule = template["schedule"]
+    zone = ZoneInfo(schedule.get("timezone", "Asia/Tokyo"))
+    start = datetime.combine(local_day, parse_clock(schedule["start_time"]), zone)
+    end: datetime | None = None
+    if schedule.get("end_time"):
+        end = datetime.combine(local_day, parse_clock(schedule["end_time"]), zone)
+        if end <= start:
+            end += timedelta(days=1)
+    series_id = str(template["series_id"])
+    event = {
+        "source_id": f"{series_id}:{local_day.isoformat()}",
+        "title": template["title"],
+        "starts_at": utc_text(start),
+        "organizer": template.get("organizer"),
+        "location": template.get("location"),
+        "description": template.get("description"),
+        "url": template.get("url"),
+        "category": template.get("category"),
+        "tags": list(template.get("tags") or []),
+        "confidence": 1.0,
+        "review_required": False,
+    }
+    if end:
+        event["ends_at"] = utc_text(end)
+    return {key: value for key, value in event.items() if value is not None}
+
+
+def materialize_weekly(template: dict[str, Any], first_day: date, last_day: date) -> list[dict[str, Any]]:
+    weekdays = {WEEKDAYS[item] for item in template["schedule"].get("weekdays", [])}
+    if not weekdays:
+        raise ValueError(f"{template['series_id']}: weekly schedule has no weekdays")
+    result: list[dict[str, Any]] = []
+    current = first_day
+    while current <= last_day:
+        if current.weekday() in weekdays:
+            result.append(event_for_date(template, current))
+        current += timedelta(days=1)
+    return result
+
+
+def materialize_monthly_nth_weekday(template: dict[str, Any], first_day: date, last_day: date) -> list[dict[str, Any]]:
+    schedule = template["schedule"]
+    weekday = WEEKDAYS[schedule["weekday"]]
+    nth = int(schedule["nth"])
+    if nth == 0 or not -5 <= nth <= 5:
+        raise ValueError(f"{template['series_id']}: nth must be between -5 and 5 excluding 0")
+    result: list[dict[str, Any]] = []
+    cursor = first_day.replace(day=1)
+    while cursor <= last_day:
+        if cursor.month == 12:
+            next_month = cursor.replace(year=cursor.year + 1, month=1)
+        else:
+            next_month = cursor.replace(month=cursor.month + 1)
+        matching_days: list[date] = []
+        day = cursor
+        while day < next_month:
+            if day.weekday() == weekday:
+                matching_days.append(day)
+            day += timedelta(days=1)
+        try:
+            occurrence = matching_days[nth - 1] if nth > 0 else matching_days[nth]
+        except IndexError:
+            occurrence = None
+        if occurrence and first_day <= occurrence <= last_day:
+            result.append(event_for_date(template, occurrence))
+        cursor = next_month
+    return result
+
+
+def materialize(
+    recurring: list[dict[str, Any]],
+    one_off: list[dict[str, Any]],
+    *,
+    now: datetime,
+    past_days: int,
+    future_days: int,
+) -> list[dict[str, Any]]:
+    lower = now.astimezone(UTC) - timedelta(days=past_days)
+    upper = now.astimezone(UTC) + timedelta(days=future_days)
+    first_day = lower.astimezone(ZoneInfo("Asia/Tokyo")).date()
+    last_day = upper.astimezone(ZoneInfo("Asia/Tokyo")).date()
+
+    events: list[dict[str, Any]] = []
+    for template in recurring:
+        frequency = template.get("schedule", {}).get("frequency")
+        if frequency == "weekly":
+            events.extend(materialize_weekly(template, first_day, last_day))
+        elif frequency == "monthly_nth_weekday":
+            events.extend(materialize_monthly_nth_weekday(template, first_day, last_day))
+        else:
+            raise ValueError(f"{template.get('series_id')}: unsupported frequency {frequency}")
+
+    for event in one_off:
+        start = parse_instant(str(event["starts_at"]))
+        if lower <= start <= upper:
+            events.append(dict(event))
+
+    unique: dict[str, dict[str, Any]] = {}
+    for event in events:
+        source_id = str(event["source_id"])
+        if source_id in unique:
+            raise ValueError(f"duplicate source_id: {source_id}")
+        unique[source_id] = event
+    return sorted(unique.values(), key=lambda item: (parse_instant(str(item["starts_at"])), str(item["title"])))
+
+
+def read_array(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list) or not all(isinstance(item, dict) for item in data):
+        raise ValueError(f"{path} must contain an array of objects")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Materialize rolling VRChat event occurrences")
+    parser.add_argument("--recurring", type=Path, default=Path("data/recurring_events.json"))
+    parser.add_argument("--one-off", type=Path, default=Path("data/one_off_events.json"))
+    parser.add_argument("--output", type=Path, default=Path("data/manual_events.json"))
+    parser.add_argument("--past-days", type=int, default=1)
+    parser.add_argument("--future-days", type=int, default=120)
+    parser.add_argument("--now", help="ISO 8601 instant for deterministic validation")
+    args = parser.parse_args()
+
+    now = parse_instant(args.now) if args.now else datetime.now(UTC).replace(microsecond=0)
+    events = materialize(
+        read_array(args.recurring),
+        read_array(args.one_off),
+        now=now,
+        past_days=args.past_days,
+        future_days=args.future_days,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(events, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"materialized {len(events)} events to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_materialize_events.py
+++ b/tests/test_materialize_events.py
@@ -1,0 +1,45 @@
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+
+from scripts.materialize_events import materialize, read_array
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_materializes_rolling_120_day_window():
+    events = materialize(
+        read_array(ROOT / "data/recurring_events.json"),
+        read_array(ROOT / "data/one_off_events.json"),
+        now=datetime(2026, 8, 1, 21, 52, tzinfo=UTC),
+        past_days=1,
+        future_days=120,
+    )
+    assert len(events) == 70
+    assert len({event["source_id"] for event in events}) == 70
+    assert events[0]["starts_at"] == "2026-08-05T12:00:00Z"
+    assert events[-1]["starts_at"] == "2026-11-27T13:00:00Z"
+    titles = {event["title"] for event in events}
+    assert {
+        "水曜Quest初心者の集い",
+        "ゆるゲMEET定期開催日",
+        "VRC初心者ワールドツアー",
+        "VRCふれあい動物園",
+        "Pyropaw Pyrocon Showcase",
+        "VRTon 2026",
+    } <= titles
+
+
+def test_generated_json_roundtrip(tmp_path):
+    events = materialize(
+        read_array(ROOT / "data/recurring_events.json"),
+        read_array(ROOT / "data/one_off_events.json"),
+        now=datetime(2026, 8, 1, 21, 52, tzinfo=UTC),
+        past_days=1,
+        future_days=120,
+    )
+    output = tmp_path / "events.json"
+    output.write_text(json.dumps(events, ensure_ascii=False), encoding="utf-8")
+    loaded = json.loads(output.read_text(encoding="utf-8"))
+    assert loaded == events

--- a/tests/test_materialize_events.py
+++ b/tests/test_materialize_events.py
@@ -1,5 +1,5 @@
-from datetime import UTC, datetime
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 from scripts.materialize_events import materialize, read_array


### PR DESCRIPTION
## 変更内容

- 公開一次情報で確認した週次イベント4系列を追加
- 定期系列を未来120日まで開催日単位に展開する`materialize_events.py`を追加
- 確認済み単発イベントを独立データへ分離し、VRTon 2026を追加
- 基準時刻2026-08-02 06:52 JSTで70件になる決定論的テストを追加
- CIと定期更新へ60件以上のカバレッジゲートを追加
- 生成済み`manual_events.json`と`public/`を6時間ごとに自動commitする構成へ更新

## 根本原因

定期イベントをシリーズ1件として保存しており、各開催日へ展開していなかったため、公開カレンダーが2件しか表示していませんでした。

## 検証

- ローカルmaterializer: 70件、source_id重複0件
- pytest: 2 tests passed
- PR CIでPython 3.11、3.12、3.13、Ruff、全テスト、本番生成を検証
