### PR TITLE
Finalize Yahoo query and selection policy v1.8

### DIFF
--- a/config/yahoo-v18-trigger.txt
+++ b/config/yahoo-v18-trigger.txt
@@ -1,0 +1,1 @@
+Execute the compact, precision-preserving Yahoo query and selection policy v1.8 finalizer.


### PR DESCRIPTION
Executes the compact trusted finalizer against the latest main. Expected corpus result: retain all 31 high-precision baseline events, add the valid朗読ミュージカル candidate, reject the streaming-only candidate, keep the hard retweet threshold at 3, and produce exactly 32 accepted Yahoo events after regression and corpus validation.