### PR TITLE
Finalize Yahoo query and selection policy v1.8

### DIFF
--- a/config/yahoo-v18-trigger.txt
+++ b/config/yahoo-v18-trigger.txt
@@ -1,0 +1,1 @@
+Execute the final tested Yahoo query and selection policy v1.8 materialization.


### PR DESCRIPTION
Applies the fully tested v1.8 policy to the retained 1,569-candidate corpus. The hard retweet threshold remains 3. The finalizer retains the 31 high-precision baseline events, adds the valid朗読ミュージカル candidate, rejects the streaming-only candidate, validates exactly 32 accepted events, runs 47 regression tests, regenerates the calendar, and removes all temporary migration machinery before merge.