### PR TITLE
Commit Yahoo query and selection policy v1.8

### DIFF
--- a/config/yahoo-v18-trigger.txt
+++ b/config/yahoo-v18-trigger.txt
@@ -1,0 +1,1 @@
+Commit the fully validated Yahoo query and selection policy v1.8.


### PR DESCRIPTION
Final commit pass for the already validated v1.8 policy. The workflow must complete 47 tests, reclassify 1,569 candidates to exactly 32 accepted and 1,537 rejected, preserve the hard retweet threshold of 3, reject known giveaways and the streaming-only candidate, remove temporary migration files, and push the tested generated outputs to this PR branch.