### PR TITLE
Empirically ablate Yahoo event search queries

### DIFF
--- a/.github/workflows/yahoo-query-ablation.yml
+++ b/.github/workflows/yahoo-query-ablation.yml
@@ -1,0 +1,104 @@
+name: Yahoo query ablation
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '47 20 * * *'
+  pull_request:
+    paths:
+      - config/yahoo_query_ablation.json
+      - scripts/run_yahoo_query_ablation.py
+      - tests/test_yahoo_query_ablation.py
+      - .github/workflows/yahoo-query-ablation.yml
+  push:
+    branches: [main]
+    paths:
+      - config/yahoo_query_ablation.json
+      - scripts/run_yahoo_query_ablation.py
+      - tests/test_yahoo_query_ablation.py
+      - .github/workflows/yahoo-query-ablation.yml
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: yahoo-query-ablation-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  ablation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+      - name: Verify ablation implementation
+        run: |
+          ruff check scripts/run_yahoo_query_ablation.py tests/test_yahoo_query_ablation.py
+          pytest tests/test_yahoo_query_ablation.py
+      - name: Run controlled Yahoo query ablation
+        run: python scripts/run_yahoo_query_ablation.py --require-complete
+      - name: Validate empirical output
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path('public/yahoo-query-ablation.json').read_text(encoding='utf-8'))
+          assert payload['schema_version'] == '1.0'
+          assert payload['classifier_version'] == '1.8'
+          assert payload['status'] == 'ok'
+          assert payload['variant_count'] == 10
+          assert payload['successful_variant_count'] == 10
+          assert payload['full_variant_available'] is True
+          assert set(payload['block_effects']) == {'access', 'announcement', 'platform'}
+          assert all(row['candidate_count'] > 0 for row in payload['variants'])
+          assert all('content_acceptance_rate' in row for row in payload['variants'])
+          assert all('production_acceptance_rate' in row for row in payload['variants'])
+          print('\nAblation summary')
+          for row in payload['variants']:
+              print(
+                  f"{row['key']}: candidates={row['candidate_count']} "
+                  f"new={row['new_to_ledger_count']} "
+                  f"content={row['content_accepted_count']} "
+                  f"content_rate={row['content_acceptance_rate']:.1%} "
+                  f"production={row['production_accepted_count']} "
+                  f"incremental={row.get('incremental_accepted_vs_full_count', 0)}"
+              )
+          print('Block effects:', json.dumps(payload['block_effects'], ensure_ascii=False))
+          PY
+      - name: Upload reproducible evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: yahoo-query-ablation-${{ github.sha }}
+          path: |
+            public/yahoo-query-ablation.json
+            data/yahoo-query-ablation-raw.json
+          retention-days: 30
+      - name: Commit empirical result
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add public/yahoo-query-ablation.json data/yahoo-query-ablation-raw.json
+          if git diff --cached --quiet; then
+            echo 'No ablation result changes'
+          else
+            git commit -m 'chore: refresh Yahoo query ablation [skip ci]'
+            git pull --rebase origin main
+            git push origin HEAD:main
+          fi
+      - name: Redeploy production Pages with evidence
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run update-calendar-v2.yml --ref main

--- a/config/yahoo_query_ablation.json
+++ b/config/yahoo_query_ablation.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "1.0",
+  "classifier_version": "1.8",
+  "result_limit": 40,
+  "minimum_retweets": 3,
+  "request_delay_seconds": 0.75,
+  "full_variant_key": "abc_full",
+  "blocks": {
+    "announcement": "(イベント告知 OR 営業告知 OR 通常営業 OR 開催決定 OR OPEN OR オープン)",
+    "access": "(JOIN OR ジョイン OR リクイン OR reqin OR Group+ OR グループインスタンス OR フレンドインスタンス OR 参加方法)",
+    "platform": "(VRChat OR VRC)"
+  },
+  "variants": [
+    {
+      "key": "abc_full",
+      "label": "A+B+C（完全式）",
+      "kind": "logical_ablation",
+      "blocks": ["announcement", "access", "platform"]
+    },
+    {
+      "key": "ac_no_access",
+      "label": "A+C（参加導線なし）",
+      "kind": "logical_ablation",
+      "blocks": ["announcement", "platform"]
+    },
+    {
+      "key": "bc_no_announcement",
+      "label": "B+C（告知表現なし）",
+      "kind": "logical_ablation",
+      "blocks": ["access", "platform"]
+    },
+    {
+      "key": "ab_no_platform",
+      "label": "A+B（VRChat指定なし）",
+      "kind": "logical_ablation",
+      "blocks": ["announcement", "access"]
+    },
+    {
+      "key": "a_only",
+      "label": "Aのみ（告知表現）",
+      "kind": "logical_ablation",
+      "blocks": ["announcement"]
+    },
+    {
+      "key": "b_only",
+      "label": "Bのみ（参加導線）",
+      "kind": "logical_ablation",
+      "blocks": ["access"]
+    },
+    {
+      "key": "c_only",
+      "label": "Cのみ（VRChat）",
+      "kind": "logical_ablation",
+      "blocks": ["platform"]
+    },
+    {
+      "key": "event_announcement_access",
+      "label": "イベント告知系×参加導線",
+      "kind": "lexical_subgroup",
+      "query": "(イベント告知 OR 開催決定) (Group+ OR グループインスタンス OR JOIN OR リクイン) (VRChat OR VRC)"
+    },
+    {
+      "key": "business_open_access",
+      "label": "営業・OPEN系×参加導線",
+      "kind": "lexical_subgroup",
+      "query": "(営業告知 OR 通常営業 OR OPEN OR オープン) (Group+ OR JOIN OR リクイン OR フレンドインスタンス) (VRChat OR VRC)"
+    },
+    {
+      "key": "participation_method_access",
+      "label": "参加方法系×参加導線",
+      "kind": "lexical_subgroup",
+      "query": "(参加方法) (JOIN OR リクイン OR Group+ OR フレンド申請) (VRChat OR VRC)"
+    }
+  ]
+}

--- a/scripts/run_yahoo_query_ablation.py
+++ b/scripts/run_yahoo_query_ablation.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import collect_yahoo_corpus as corpus
+from scripts import fetch_yahoo_realtime as yahoo
+from scripts import refine_yahoo_corpus as refinement
+from scripts import run_yahoo_realtime as ledger
+
+CONFIG_PATH = Path("config/yahoo_query_ablation.json")
+PUBLIC_PATH = Path("public/yahoo-query-ablation.json")
+RAW_PATH = Path("data/yahoo-query-ablation-raw.json")
+_PRIVATE_FIELDS = {
+    "candidate_status_ids",
+    "content_accepted_status_ids",
+    "production_accepted_status_ids",
+}
+
+
+def ratio(numerator: int, denominator: int) -> float:
+    return round(numerator / denominator, 6) if denominator else 0.0
+
+
+def jaccard(left: set[str], right: set[str]) -> float:
+    return ratio(len(left & right), len(left | right))
+
+
+def build_query_plan(config: dict[str, Any]) -> list[dict[str, str]]:
+    blocks, variants = config.get("blocks"), config.get("variants")
+    if not isinstance(blocks, dict) or not isinstance(variants, list):
+        raise ValueError("Ablation config requires blocks and variants")
+    plan, keys, queries = [], set(), set()
+    for item in variants:
+        if not isinstance(item, dict):
+            raise ValueError("Each variant must be an object")
+        key = str(item.get("key") or "").strip()
+        if not key or key in keys:
+            raise ValueError(f"Duplicate or empty variant key: {key!r}")
+        query = str(item.get("query") or "").strip()
+        if not query:
+            names = item.get("blocks")
+            if not isinstance(names, list) or not names:
+                raise ValueError(f"Variant {key} requires query or blocks")
+            missing = [str(name) for name in names if str(name) not in blocks]
+            if missing:
+                raise ValueError(f"Variant {key} has unknown blocks: {missing}")
+            query = " ".join(str(blocks[str(name)]).strip() for name in names)
+        if query.casefold() in queries:
+            raise ValueError(f"Duplicate query for {key}")
+        keys.add(key)
+        queries.add(query.casefold())
+        plan.append(
+            {
+                "key": key,
+                "label": str(item.get("label") or key),
+                "kind": str(item.get("kind") or "unspecified"),
+                "query": query,
+                "url": "https://search.yahoo.co.jp/realtime/search?"
+                + urlencode({"ei": "UTF-8", "p": query, "md": "h"}),
+            }
+        )
+    if str(config.get("full_variant_key")) not in keys:
+        raise ValueError("full_variant_key must reference a variant")
+    return plan
+
+
+def evaluate(
+    candidates: list[dict[str, Any]], now: datetime, minimum_retweets: int, x_ids: set[str]
+) -> tuple[set[str], Counter[str]]:
+    observed_at = yahoo.utc_text(now)
+    rows = [
+        {
+            **row,
+            "first_seen_at": observed_at,
+            "last_seen_at": observed_at,
+            "observation_count": 1,
+            "max_retweet_count": row.get("retweet_count") or 0,
+        }
+        for row in candidates
+    ]
+    accepted, _rejected, evaluated = refinement.reevaluate_with_source_time(
+        rows, actual_now=now, min_retweets=minimum_retweets, x_ids=x_ids
+    )
+    accepted_ids = {str(row.get("source_id", "")).split(":")[-1] for row in accepted}
+    reasons = Counter(
+        str(row.get("last_reason") or "unknown")
+        for row in evaluated
+        if row.get("last_decision") != "accepted"
+    )
+    return accepted_ids, reasons
+
+
+def fetch_variant(
+    variant: dict[str, str],
+    *,
+    now: datetime,
+    minimum_retweets: int,
+    result_limit: int,
+    ledger_ids: set[str],
+    x_ids: set[str],
+) -> dict[str, Any]:
+    started = time.monotonic()
+    yahoo.validate_search_url(variant["url"])
+    html, status, final_url = yahoo.fetch_page(variant["url"])
+    candidates = list({str(row["status_id"]): row for row in yahoo.extract_candidates(html)}.values())
+    if not candidates:
+        raise RuntimeError("no direct Yahoo post objects")
+    candidate_ids = {str(row["status_id"]) for row in candidates}
+    content_ids, reasons = evaluate(candidates, now, minimum_retweets, set())
+    production_ids, _ = evaluate(candidates, now, minimum_retweets, x_ids)
+    new_ids = candidate_ids - ledger_ids
+    return {
+        **{name: variant[name] for name in ("key", "label", "kind", "query")},
+        "status": "ok",
+        "http_status": status,
+        "final_url": final_url,
+        "duration_ms": int((time.monotonic() - started) * 1000),
+        "candidate_count": len(candidate_ids),
+        "result_limit": result_limit,
+        "result_limit_reached": len(candidate_ids) >= result_limit,
+        "new_to_ledger_count": len(new_ids),
+        "new_to_ledger_rate": ratio(len(new_ids), len(candidate_ids)),
+        "content_accepted_count": len(content_ids),
+        "content_acceptance_rate": ratio(len(content_ids), len(candidate_ids)),
+        "production_accepted_count": len(production_ids),
+        "production_acceptance_rate": ratio(len(production_ids), len(candidate_ids)),
+        "new_content_accepted_count": len(content_ids & new_ids),
+        "new_production_accepted_count": len(production_ids & new_ids),
+        "rejection_reason_counts": dict(sorted(reasons.items())),
+        "candidate_status_ids": sorted(candidate_ids),
+        "content_accepted_status_ids": sorted(content_ids),
+        "production_accepted_status_ids": sorted(production_ids),
+    }
+
+
+def enrich(results: list[dict[str, Any]], full_key: str) -> dict[str, Any]:
+    successful = {str(row["key"]): row for row in results if row.get("status") == "ok"}
+    full = successful.get(full_key)
+    if full is None:
+        return {"full_variant_available": False, "block_effects": {}}
+    full_candidates = set(full["candidate_status_ids"])
+    full_accepted = set(full["content_accepted_status_ids"])
+    accepted_by_key = {
+        key: set(row["content_accepted_status_ids"]) for key, row in successful.items()
+    }
+    for key, row in successful.items():
+        candidates, accepted = set(row["candidate_status_ids"]), accepted_by_key[key]
+        others = set().union(*(values for other, values in accepted_by_key.items() if other != key))
+        row.update(
+            {
+                "candidate_overlap_with_full_count": len(candidates & full_candidates),
+                "candidate_jaccard_with_full": jaccard(candidates, full_candidates),
+                "accepted_overlap_with_full_count": len(accepted & full_accepted),
+                "accepted_jaccard_with_full": jaccard(accepted, full_accepted),
+                "incremental_accepted_vs_full_count": len(accepted - full_accepted),
+                "exclusive_accepted_count": len(accepted - others),
+            }
+        )
+    effects = {}
+    for block, ablated_key in {
+        "access": "ac_no_access",
+        "announcement": "bc_no_announcement",
+        "platform": "ab_no_platform",
+    }.items():
+        ablated = successful.get(ablated_key)
+        if not ablated:
+            continue
+        ablated_ids = set(ablated["content_accepted_status_ids"])
+        effects[block] = {
+            "full_key": full_key,
+            "ablated_key": ablated_key,
+            "precision_delta_full_minus_ablated": round(
+                float(full["content_acceptance_rate"])
+                - float(ablated["content_acceptance_rate"]),
+                6,
+            ),
+            "accepted_yield_delta_full_minus_ablated": int(full["content_accepted_count"])
+            - int(ablated["content_accepted_count"]),
+            "accepted_lost_when_removed_count": len(full_accepted - ablated_ids),
+            "accepted_gained_when_removed_count": len(ablated_ids - full_accepted),
+        }
+    return {"full_variant_available": True, "block_effects": effects}
+
+
+def run(config_path: Path = CONFIG_PATH) -> dict[str, Any]:
+    config = corpus.read_json(config_path, {})
+    if not isinstance(config, dict):
+        raise ValueError("Ablation config must be an object")
+    corpus.configure_classifier()
+    yahoo.PARSER_VERSION = str(config.get("classifier_version") or yahoo.PARSER_VERSION)
+    now = datetime.now(UTC).replace(microsecond=0)
+    minimum_retweets = int(config.get("minimum_retweets") or 3)
+    result_limit = int(config.get("result_limit") or 40)
+    delay = max(0.0, float(config.get("request_delay_seconds") or 0.0))
+    plan = build_query_plan(config)
+    history = corpus.read_json(ledger.HISTORY_PATH, {})
+    old_rows = history.get("candidates", []) if isinstance(history, dict) else []
+    ledger_ids = {str(row.get("status_id")) for row in old_rows if isinstance(row, dict)}
+    x_ids = yahoo.known_x_ids(yahoo.read_array(yahoo.X_EVENTS_PATH))
+    results = []
+    for index, variant in enumerate(plan):
+        try:
+            result = fetch_variant(
+                variant,
+                now=now,
+                minimum_retweets=minimum_retweets,
+                result_limit=result_limit,
+                ledger_ids=ledger_ids,
+                x_ids=x_ids,
+            )
+        except (RuntimeError, ValueError) as exc:
+            result = {
+                **{name: variant[name] for name in ("key", "label", "kind", "query")},
+                "status": "failed",
+                "reason": str(exc),
+                "candidate_count": 0,
+                "content_accepted_count": 0,
+                "production_accepted_count": 0,
+            }
+        results.append(result)
+        print(
+            f"{result['key']}: {result['status']} candidates={result.get('candidate_count', 0)} "
+            f"content={result.get('content_accepted_count', 0)} "
+            f"production={result.get('production_accepted_count', 0)}"
+        )
+        if delay and index + 1 < len(plan):
+            time.sleep(delay)
+    comparison = enrich(results, str(config["full_variant_key"]))
+    successful = sum(row.get("status") == "ok" for row in results)
+    payload = {
+        "schema_version": "1.0",
+        "generated_at": yahoo.utc_text(now),
+        "classifier_version": yahoo.PARSER_VERSION,
+        "status": "ok" if successful == len(results) else ("degraded" if successful else "failed"),
+        "variant_count": len(results),
+        "successful_variant_count": successful,
+        "failed_variant_count": len(results) - successful,
+        "existing_ledger_candidate_count": len(ledger_ids),
+        "existing_x_source_count": len(x_ids),
+        "full_variant_key": config["full_variant_key"],
+        "experiment_design": {
+            "same_execution_time": True,
+            "same_result_limit": result_limit,
+            "same_classifier": True,
+            "minimum_retweets": minimum_retweets,
+            "content_precision_ignores_x_source_deduplication": True,
+            "production_precision_applies_x_source_deduplication": True,
+        },
+        "variants": [{key: value for key, value in row.items() if key not in _PRIVATE_FIELDS} for row in results],
+        **comparison,
+        "limitations": [
+            "Yahoo realtime ranking is time-dependent.",
+            "Result-limit conditions estimate top-K precision, not corpus recall.",
+            "Removing the platform block intentionally permits non-VRChat results.",
+        ],
+    }
+    yahoo.write_json(PUBLIC_PATH, payload)
+    yahoo.write_json(
+        RAW_PATH,
+        {
+            "schema_version": "1.0",
+            "generated_at": payload["generated_at"],
+            "classifier_version": payload["classifier_version"],
+            "variants": [
+                {
+                    "key": row["key"],
+                    "query": row["query"],
+                    "candidate_status_ids": row.get("candidate_status_ids", []),
+                    "content_accepted_status_ids": row.get("content_accepted_status_ids", []),
+                    "production_accepted_status_ids": row.get("production_accepted_status_ids", []),
+                }
+                for row in results
+            ],
+        },
+    )
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, default=CONFIG_PATH)
+    parser.add_argument("--require-complete", action="store_true")
+    args = parser.parse_args(argv)
+    payload = run(args.config)
+    print(
+        f"Yahoo query ablation: {payload['status']} "
+        f"{payload['successful_variant_count']}/{payload['variant_count']}"
+    )
+    if args.require_complete and payload["successful_variant_count"] != payload["variant_count"]:
+        return 1
+    return 0 if payload["successful_variant_count"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_yahoo_query_ablation.py
+++ b/tests/test_yahoo_query_ablation.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import run_yahoo_query_ablation as ablation
+
+
+def test_query_plan_contains_all_logical_and_lexical_ablations() -> None:
+    config = json.loads(Path("config/yahoo_query_ablation.json").read_text(encoding="utf-8"))
+    plan = ablation.build_query_plan(config)
+    by_key = {row["key"]: row for row in plan}
+
+    assert len(plan) == 10
+    assert len({row["query"].casefold() for row in plan}) == 10
+    assert set(by_key) >= {
+        "abc_full",
+        "ac_no_access",
+        "bc_no_announcement",
+        "ab_no_platform",
+        "a_only",
+        "b_only",
+        "c_only",
+        "event_announcement_access",
+        "business_open_access",
+        "participation_method_access",
+    }
+    assert "イベント告知" in by_key["abc_full"]["query"]
+    assert "JOIN" in by_key["abc_full"]["query"]
+    assert "VRChat" in by_key["abc_full"]["query"]
+    assert "JOIN" not in by_key["ac_no_access"]["query"]
+    assert "イベント告知" not in by_key["bc_no_announcement"]["query"]
+    assert "VRChat" not in by_key["ab_no_platform"]["query"]
+
+
+def test_enrich_calculates_block_effects_and_incremental_accepts() -> None:
+    results = [
+        {
+            "key": "abc_full",
+            "status": "ok",
+            "content_acceptance_rate": 0.5,
+            "content_accepted_count": 2,
+            "candidate_status_ids": ["1", "2", "8", "9"],
+            "content_accepted_status_ids": ["1", "2"],
+        },
+        {
+            "key": "ac_no_access",
+            "status": "ok",
+            "content_acceptance_rate": 0.25,
+            "content_accepted_count": 1,
+            "candidate_status_ids": ["1", "3", "4", "5"],
+            "content_accepted_status_ids": ["1"],
+        },
+        {
+            "key": "bc_no_announcement",
+            "status": "ok",
+            "content_acceptance_rate": 0.75,
+            "content_accepted_count": 2,
+            "candidate_status_ids": ["2", "3", "6", "7"],
+            "content_accepted_status_ids": ["2", "3"],
+        },
+        {
+            "key": "ab_no_platform",
+            "status": "ok",
+            "content_acceptance_rate": 0.25,
+            "content_accepted_count": 1,
+            "candidate_status_ids": ["4", "10", "11", "12"],
+            "content_accepted_status_ids": ["4"],
+        },
+    ]
+
+    comparison = ablation.enrich(results, "abc_full")
+
+    assert comparison["full_variant_available"] is True
+    assert results[2]["incremental_accepted_vs_full_count"] == 1
+    assert results[3]["exclusive_accepted_count"] == 1
+    assert comparison["block_effects"]["access"] == {
+        "full_key": "abc_full",
+        "ablated_key": "ac_no_access",
+        "precision_delta_full_minus_ablated": 0.25,
+        "accepted_yield_delta_full_minus_ablated": 1,
+        "accepted_lost_when_removed_count": 1,
+        "accepted_gained_when_removed_count": 0,
+    }
+    assert comparison["block_effects"]["announcement"]["precision_delta_full_minus_ablated"] == -0.25
+    assert comparison["block_effects"]["announcement"]["accepted_gained_when_removed_count"] == 1
+    assert comparison["block_effects"]["platform"]["accepted_lost_when_removed_count"] == 2
+
+
+def test_ratio_and_jaccard_are_zero_safe() -> None:
+    assert ablation.ratio(0, 0) == 0.0
+    assert ablation.jaccard(set(), set()) == 0.0
+    assert ablation.jaccard({"1", "2"}, {"2", "3"}) == 0.333333


### PR DESCRIPTION
## Purpose
Measure the actual contribution of announcement terms (A), VRChat participation/access terms (B), and platform terms (C), rather than inferring quality from the whole Yahoo candidate ledger.

## Controlled experiment
- Same execution timestamp
- Same classifier: v1.8
- Same retweet threshold: 3
- Same Yahoo top-40 limit
- Seven non-empty A/B/C combinations plus three lexical subgroup queries

## Live result (2026-08-02 19:18 JST)
All 10/10 queries completed with HTTP 200 and all reached the 40-result cap.

- A+B+C full: 14/40 accepted (35.0%), 2 new ledger candidates
- A+C without access: 11/40 (27.5%), 4 accepted outside the full query
- B+C without announcement: 11/40 (27.5%), 5 accepted outside the full query
- A+B without platform: 10/40 (25.0%), 7 accepted outside the full query, but 21/40 rejected as non-VRChat
- A only: 0/40
- B only: 0/40
- C only: 1/40 (2.5%)
- Event-announcement subgroup: 8/40 (20.0%), 1 accepted outside full
- Business/OPEN subgroup: 6/40 (15.0%), 0 accepted outside full
- Participation-method subgroup: 2/40 (5.0%), 1 accepted outside full

Removing access or announcement reduced top-40 precision by 7.5 percentage points. Removing the platform block reduced it by 10 points. The full three-block expression is therefore the best primary query, while narrower/ablated queries remain useful as complementary recall shards because Yahoo ranking changes the top-40 set.

## Outputs
- `public/yahoo-query-ablation.json`: compact public metrics
- `data/yahoo-query-ablation-raw.json`: reproducible status-ID sets
- Daily workflow at 05:47 JST, plus PR/push/manual execution
- Main runs commit evidence and dispatch the production Pages workflow

## Validation
- CI succeeded
- Ruff succeeded
- 3 focused pytest tests succeeded
- Live ablation workflow succeeded
- 10/10 live-query completion and output-schema gate succeeded
