### PR TITLE
Refresh canonical Pages after Yahoo best-1000

### DIFF
--- a/.github/workflows/refresh-pages-now.yml
+++ b/.github/workflows/refresh-pages-now.yml
@@ -1,0 +1,184 @@
+name: Refresh canonical Pages now
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/refresh-pages-now.yml
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: refresh-canonical-pages-now
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+
+      - name: Reclassify current Yahoo ledger
+        env:
+          YAHOO_MIN_RETWEETS: '3'
+        run: python scripts/refine_yahoo_corpus.py
+
+      - name: Rebuild calendar and frontend
+        run: |
+          python main_executor.py run --strict
+          python scripts/render_frontend.py
+
+      - name: Validate regenerated assets
+        run: |
+          set -euo pipefail
+          grep -q 'VRChat Event Calendar' public/index.html
+          grep -q 'BEGIN:VCALENDAR' public/calendar.ics
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path('.')
+          history = json.loads((root / 'public/yahoo-candidate-history.json').read_text(encoding='utf-8'))
+          classifier = json.loads((root / 'public/yahoo-classifier-audit.json').read_text(encoding='utf-8'))
+          yahoo_events = json.loads((root / 'data/yahoo_realtime_events.json').read_text(encoding='utf-8'))
+          events = json.loads((root / 'public/events.json').read_text(encoding='utf-8'))
+          health = json.loads((root / 'public/health.json').read_text(encoding='utf-8'))
+          best = json.loads((root / 'public/yahoo-best-1000-audit.json').read_text(encoding='utf-8'))
+
+          sources = {row['name']: row for row in health['sources']}
+          assert history['candidate_count'] >= 2429
+          assert classifier['classifier_version'] == '1.8'
+          assert classifier['candidate_count'] == history['candidate_count']
+          assert classifier['accepted_count'] == len(yahoo_events)
+          assert classifier['accepted_count'] + classifier['rejected_count'] == history['candidate_count']
+          assert classifier['quality']['duplicate_status_ids'] == 0
+          assert classifier['quality']['missing_source_created_at'] == 0
+          assert classifier['quality']['ambiguous_decisions'] == 0
+          assert events['count'] == len(events['events'])
+          assert health['event_count'] == events['count']
+          assert sources['yahoo_realtime_events']['count'] == classifier['accepted_count']
+          assert best['status'] == 'ok'
+          assert best['candidate_count'] == 1000
+          assert best['target_reached'] is True
+          PY
+
+      - name: Commit regenerated assets
+        run: |
+          set -euo pipefail
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add \
+            data/yahoo_realtime_events.json \
+            data/yahoo_realtime_rejected.json \
+            data/yahoo_realtime_health.json \
+            public
+          if git diff --cached --quiet; then
+            echo 'Canonical assets already current'
+          else
+            git commit -m 'chore: refresh canonical Pages assets [skip ci]'
+            git pull --rebase origin main
+            git push origin HEAD:main
+          fi
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  verify:
+    needs: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Verify deployed canonical Pages
+        env:
+          PAGE_URL: ${{ needs.deploy.outputs.page_url }}
+        run: |
+          set -euo pipefail
+          base="${PAGE_URL%/}"
+          verified=false
+          for attempt in $(seq 1 30); do
+            root_status="$(curl -sS --connect-timeout 10 --max-time 20 -o /tmp/live-index.html -w '%{http_code}' "$base/" || true)"
+            events_status="$(curl -sS --connect-timeout 10 --max-time 20 -o /tmp/live-events.json -w '%{http_code}' "$base/events.json" || true)"
+            history_status="$(curl -sS --connect-timeout 10 --max-time 20 -o /tmp/live-history.json -w '%{http_code}' "$base/yahoo-candidate-history.json" || true)"
+            classifier_status="$(curl -sS --connect-timeout 10 --max-time 20 -o /tmp/live-classifier.json -w '%{http_code}' "$base/yahoo-classifier-audit.json" || true)"
+            best_status="$(curl -sS --connect-timeout 10 --max-time 20 -o /tmp/live-best.json -w '%{http_code}' "$base/yahoo-best-1000-audit.json" || true)"
+            if [ "$root_status" = '200' ] \
+              && [ "$events_status" = '200' ] \
+              && [ "$history_status" = '200' ] \
+              && [ "$classifier_status" = '200' ] \
+              && [ "$best_status" = '200' ] \
+              && python - <<'PY'
+          import json
+          events = json.load(open('/tmp/live-events.json', encoding='utf-8'))
+          history = json.load(open('/tmp/live-history.json', encoding='utf-8'))
+          classifier = json.load(open('/tmp/live-classifier.json', encoding='utf-8'))
+          best = json.load(open('/tmp/live-best.json', encoding='utf-8'))
+          assert history['candidate_count'] >= 2429
+          assert classifier['candidate_count'] == history['candidate_count']
+          assert classifier['accepted_count'] + classifier['rejected_count'] == history['candidate_count']
+          assert events['count'] >= classifier['accepted_count']
+          assert best['candidate_count'] == 1000
+          assert best['status'] == 'ok'
+          PY
+            then
+              verified=true
+              break
+            fi
+            sleep 10
+          done
+          test "$verified" = true
+
+  cleanup:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Remove one-time workflow and work branch
+        run: |
+          set -euo pipefail
+          git push origin --delete agent/refresh-pages-20260803 || true
+          rm .github/workflows/refresh-pages-now.yml
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add .github/workflows/refresh-pages-now.yml
+          git commit -m 'chore: remove completed Pages refresh workflow [skip ci]'
+          git pull --rebase origin main
+          git push origin HEAD:main


### PR DESCRIPTION
Rebuild the calendar from the current 2,429-candidate Yahoo ledger, regenerate frontend assets, deploy canonical GitHub Pages, verify the best-1000 evidence endpoint, then remove the one-time workflow and work branch.