### PR TITLE
Trigger Yahoo v1.9 materializer

### DIFF
--- a/.github/workflows/materialize-yahoo-v19-once.yml
+++ b/.github/workflows/materialize-yahoo-v19-once.yml
@@ -1,3 +1,4 @@
+# merge-trigger: 2026-08-03
 name: Materialize Yahoo v1.9 once
 
 on:


### PR DESCRIPTION
Trigger the already-reviewed one-time materializer through a normal main-branch merge so the feature branch is patched, tested, replayed against all 2,429 candidates, and the temporary workflow self-removes.