### PR TITLE
Accept past and low-retweet Yahoo events

### DIFF
--- a/.github/workflows/reclassify-yahoo-archive.yml
+++ b/.github/workflows/reclassify-yahoo-archive.yml
@@ -1,0 +1,131 @@
+name: Reclassify Yahoo archive and deploy Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - scripts/reclassify_yahoo_archive.py
+      - tests/test_yahoo_archive_policy.py
+      - .github/workflows/reclassify-yahoo-archive.yml
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: cast-event-calendar-production
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+      - name: Run regression tests
+        run: pytest -q tests/test_yahoo_archive_policy.py tests/test_yahoo_corpus.py
+      - name: Reclassify acquired Yahoo database
+        run: python scripts/reclassify_yahoo_archive.py
+      - name: Rebuild normalized calendar and frontend
+        run: |
+          python main_executor.py run --strict
+          python scripts/render_frontend.py
+      - name: Validate archive policy and generated data
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          events = json.loads(Path('data/yahoo_realtime_events.json').read_text(encoding='utf-8'))
+          rejected = json.loads(Path('data/yahoo_realtime_rejected.json').read_text(encoding='utf-8'))
+          health = json.loads(Path('data/yahoo_realtime_health.json').read_text(encoding='utf-8'))
+          history = json.loads(Path('public/yahoo-candidate-history.json').read_text(encoding='utf-8'))
+          audit = json.loads(Path('public/yahoo-classifier-audit.json').read_text(encoding='utf-8'))
+          public_events = json.loads(Path('public/events.json').read_text(encoding='utf-8'))
+
+          assert history.get('schema_version') == '2.4'
+          assert audit.get('schema_version') == '1.4'
+          assert audit.get('classifier_version') == '1.9'
+          assert health.get('parser_version') == '1.9'
+          assert health.get('history_accepted_count') == len(events)
+          assert health.get('history_rejected_count') == len(rejected)
+          assert audit.get('accepted_count') == len(events)
+          assert audit.get('rejected_count') == len(rejected)
+          assert audit.get('past_accepted_count', 0) > 0
+          assert audit.get('low_retweet_accepted_count', 0) > 0
+          assert audit.get('rejection_reason_counts', {}).get('past_event', 0) == 0
+          assert audit.get('rejection_reason_counts', {}).get('past_event_now', 0) == 0
+          assert audit.get('rejection_reason_counts', {}).get('retweet_below_threshold', 0) == 0
+          assert any(row.get('is_archived') is True for row in events)
+          assert any(int(row.get('retweet_count') or 0) < 3 for row in events)
+          assert all(row.get('temporal_status') in {'past', 'upcoming'} for row in events)
+          assert len({row['source_id'] for row in events}) == len(events)
+          assert public_events.get('count') == len(public_events.get('events', []))
+          assert Path('public/index.html').exists()
+          PY
+      - name: Commit organized generated data
+        run: |
+          set -euo pipefail
+          paths=(data/yahoo_realtime_events.json data/yahoo_realtime_rejected.json data/yahoo_realtime_health.json public audit)
+          if [ -n "$(git status --porcelain -- "${paths[@]}")" ]; then
+            git config user.name github-actions[bot]
+            git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+            git add "${paths[@]}"
+            git commit -m 'chore: organize Yahoo archive database [skip ci]'
+            git pull --rebase origin main
+            git push origin HEAD:main
+          fi
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  verify:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify Pages archive data
+        env:
+          PAGE_URL: ${{ needs.deploy.outputs.page_url }}
+        run: |
+          set -euo pipefail
+          base="${PAGE_URL%/}"
+          for attempt in $(seq 1 30); do
+            if curl -fsS "$base/yahoo-classifier-audit.json" -o /tmp/audit.json && \
+               curl -fsS "$base/events.json" -o /tmp/events.json && \
+               python - <<'PY'
+          import json
+          audit = json.load(open('/tmp/audit.json', encoding='utf-8'))
+          events = json.load(open('/tmp/events.json', encoding='utf-8'))
+          assert audit.get('classifier_version') == '1.9'
+          assert audit.get('past_accepted_count', 0) > 0
+          assert audit.get('low_retweet_accepted_count', 0) > 0
+          assert events.get('count', 0) > 0
+          PY
+            then exit 0; fi
+            sleep 10
+          done
+          exit 1

--- a/scripts/reclassify_yahoo_archive.py
+++ b/scripts/reclassify_yahoo_archive.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import collect_yahoo_corpus as corpus
+from scripts import fetch_yahoo_realtime as implementation
+from scripts import refine_yahoo_corpus as refinement
+from scripts import run_yahoo_realtime as ledger
+
+ARCHIVE_RETENTION_DAYS = 365
+
+
+def temporal_status(start: datetime, now: datetime) -> str:
+    return "past" if start < now else "upcoming"
+
+
+def adjusted_candidate(row: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    candidate = {
+        "status_id": str(row.get("status_id") or ""),
+        "url": row.get("url"),
+        "text": row.get("text"),
+        "author": row.get("author"),
+        "retweet_count": row.get("retweet_count"),
+    }
+    value = candidate.get("retweet_count")
+    if value is None:
+        return None, "retweet_count_missing"
+    try:
+        count = int(value)
+    except (TypeError, ValueError):
+        return None, "retweet_count_invalid"
+    if count < 0:
+        return None, "retweet_count_invalid"
+    candidate["retweet_count"] = max(count, 3)
+    return candidate, None
+
+
+def reclassify(
+    history: list[dict[str, Any]],
+    *,
+    actual_now: datetime,
+    x_ids: set[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    accepted: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    evaluated: list[dict[str, Any]] = []
+
+    for original in history:
+        row = dict(original)
+        status_id = str(row.get("status_id") or "")
+        source_created_at = refinement.twitter_snowflake_created_at(status_id)
+        if source_created_at and source_created_at <= actual_now + timedelta(days=1):
+            row["source_created_at"] = implementation.utc_text(source_created_at)
+        else:
+            source_created_at = None
+        anchor = (
+            source_created_at
+            or implementation.parse_instant(str(row.get("first_seen_at") or ""))
+            or actual_now
+        )
+
+        candidate, reason = adjusted_candidate(row)
+        event = None
+        if candidate is not None:
+            text = str(candidate.get("text") or "")
+            if refinement.giveaway_without_event_access(text):
+                reason = "giveaway_only"
+            else:
+                parsed = implementation.parse_event_datetime(text, anchor)
+                if parsed is None:
+                    reason = "missing_datetime"
+                elif parsed > actual_now + timedelta(days=180):
+                    reason = "too_far_future_now"
+                else:
+                    event, reason = corpus.refined_candidate_to_event(
+                        candidate,
+                        now=parsed.astimezone(UTC),
+                        min_retweets=3,
+                        x_ids=x_ids,
+                    )
+
+        if event:
+            start = implementation.parse_instant(str(event.get("starts_at") or ""))
+            if start is None:
+                event = None
+                reason = "missing_datetime"
+            else:
+                observed = int(row.get("retweet_count") or 0)
+                event["retweet_count"] = observed
+                event["temporal_status"] = temporal_status(start, actual_now)
+                event["is_archived"] = start < actual_now
+                tags = [
+                    tag
+                    for tag in event.get("tags", [])
+                    if tag != "リポスト3件以上"
+                ]
+                tags.append("終了済み" if start < actual_now else "開催予定")
+                tags.append(f"リポスト{observed}件")
+                event["tags"] = tags
+
+        if event:
+            row["last_decision"] = "accepted"
+            row["last_reason"] = None
+            accepted.append(event)
+        else:
+            resolved = reason or "unknown"
+            row["last_decision"] = "rejected"
+            row["last_reason"] = resolved
+            rejected.append(refinement.rejection_row(row, resolved))
+        evaluated.append(row)
+
+    accepted.sort(key=lambda item: (str(item.get("starts_at")), str(item.get("source_id"))))
+    rejected.sort(
+        key=lambda item: (
+            -int(item.get("retweet_count") or 0),
+            str(item.get("reason")),
+            str(item.get("status_id")),
+        )
+    )
+    return accepted, rejected, evaluated
+
+
+def main() -> int:
+    corpus.configure_classifier()
+    implementation.PARSER_VERSION = "1.9"
+    now = datetime.now(UTC).replace(microsecond=0)
+    history_payload = corpus.read_json(ledger.HISTORY_PATH, {})
+    if not isinstance(history_payload, dict):
+        raise ValueError("Yahoo candidate history must be an object")
+    history = history_payload.get("candidates", [])
+    if not isinstance(history, list):
+        raise ValueError("Yahoo candidate history candidates must be an array")
+
+    x_ids = implementation.known_x_ids(implementation.read_array(implementation.X_EVENTS_PATH))
+    accepted, rejected, evaluated = reclassify(
+        [row for row in history if isinstance(row, dict)],
+        actual_now=now,
+        x_ids=x_ids,
+    )
+
+    history_payload.update(
+        {
+            "schema_version": "2.4",
+            "generated_at": implementation.utc_text(now),
+            "candidate_count": len(evaluated),
+            "source_time_policy": "x_snowflake_created_at_then_first_seen_at",
+            "engagement_policy": "retweet_count_required_but_no_minimum",
+            "temporal_policy": f"retain_past_events_for_{ARCHIVE_RETENTION_DAYS}_day_candidate_history",
+            "giveaway_policy": "require_specific_event_or_vrchat_access_method",
+            "candidates": evaluated,
+        }
+    )
+    implementation.write_json(ledger.HISTORY_PATH, history_payload)
+    implementation.write_json(implementation.OUTPUT_PATH, accepted)
+    implementation.write_json(implementation.REJECTED_PATH, rejected)
+
+    vocabulary = refinement.build_positive_vocabulary(accepted, now)
+    vocabulary.update(
+        {
+            "minimum_retweets": 0,
+            "engagement_policy": "retweet_count_required_but_no_minimum",
+        }
+    )
+    implementation.write_json(refinement.POSITIVE_VOCABULARY_PATH, vocabulary)
+
+    previous_audit = corpus.read_json(refinement.AUDIT_PATH, {})
+    query_results = previous_audit.get("query_results", []) if isinstance(previous_audit, dict) else []
+    target = int(history_payload.get("target_count") or 1000)
+    audit = refinement.build_audit(evaluated, query_results, target, now)
+    audit.update(
+        {
+            "classifier_version": implementation.PARSER_VERSION,
+            "schema_version": "1.4",
+            "engagement_policy": "retweet_count_required_but_no_minimum",
+            "temporal_policy": "past_events_are_accepted_and_marked_archived",
+            "past_accepted_count": sum(bool(row.get("is_archived")) for row in accepted),
+            "low_retweet_accepted_count": sum(int(row.get("retweet_count") or 0) < 3 for row in accepted),
+        }
+    )
+    implementation.write_json(refinement.AUDIT_PATH, audit)
+
+    health = ledger.read_object(implementation.HEALTH_PATH)
+    health.update(
+        {
+            "schema_version": "2.3",
+            "parser_version": implementation.PARSER_VERSION,
+            "generated_at": implementation.utc_text(now),
+            "event_count": len(accepted),
+            "history_candidate_count": len(evaluated),
+            "history_accepted_count": len(accepted),
+            "history_rejected_count": len(rejected),
+            "source_timestamp_count": sum(bool(row.get("source_created_at")) for row in evaluated),
+            "engagement_policy": history_payload["engagement_policy"],
+            "temporal_policy": history_payload["temporal_policy"],
+            "rejection_counts": audit["rejection_reason_counts"],
+        }
+    )
+    implementation.write_json(implementation.HEALTH_PATH, health)
+    print(
+        "Yahoo archive reclassification: "
+        f"history={len(evaluated)} accepted={len(accepted)} rejected={len(rejected)} "
+        f"past={audit['past_accepted_count']} low_retweet={audit['low_retweet_accepted_count']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_yahoo_archive_policy.py
+++ b/tests/test_yahoo_archive_policy.py
@@ -1,0 +1,78 @@
+from datetime import UTC, datetime
+
+from scripts.collect_yahoo_corpus import configure_classifier
+from scripts.reclassify_yahoo_archive import reclassify
+
+
+def row(text: str, *, retweets: int = 0, status_id: str = "2080000000000000000"):
+    return {
+        "status_id": status_id,
+        "url": f"https://x.com/host/status/{status_id}",
+        "text": text,
+        "author": "host",
+        "retweet_count": retweets,
+        "first_seen_at": "2026-08-01T00:00:00Z",
+        "last_seen_at": "2026-08-02T00:00:00Z",
+    }
+
+
+def test_low_retweet_future_event_is_accepted():
+    configure_classifier()
+    accepted, rejected, evaluated = reclassify(
+        [row("2026/8/7 22:00 VRChatイベント開催。参加方法はGroup+へJOIN")],
+        actual_now=datetime(2026, 8, 3, tzinfo=UTC),
+        x_ids=set(),
+    )
+    assert len(accepted) == 1
+    assert rejected == []
+    assert accepted[0]["retweet_count"] == 0
+    assert accepted[0]["temporal_status"] == "upcoming"
+    assert accepted[0]["is_archived"] is False
+    assert evaluated[0]["last_decision"] == "accepted"
+
+
+def test_past_event_is_accepted_and_archived():
+    configure_classifier()
+    accepted, rejected, _ = reclassify(
+        [row("2026/7/20 22:00 VRC交流イベント開催。参加方法はJOIN", retweets=1)],
+        actual_now=datetime(2026, 8, 3, tzinfo=UTC),
+        x_ids=set(),
+    )
+    assert len(accepted) == 1
+    assert rejected == []
+    assert accepted[0]["temporal_status"] == "past"
+    assert accepted[0]["is_archived"] is True
+    assert "終了済み" in accepted[0]["tags"]
+
+
+def test_missing_retweet_count_remains_fail_closed():
+    configure_classifier()
+    candidate = row("2026/8/7 22:00 VRChatイベント開催。参加方法はJOIN")
+    candidate["retweet_count"] = None
+    accepted, rejected, _ = reclassify(
+        [candidate], actual_now=datetime(2026, 8, 3, tzinfo=UTC), x_ids=set()
+    )
+    assert accepted == []
+    assert rejected[0]["reason"] == "retweet_count_missing"
+
+
+def test_giveaway_only_remains_rejected():
+    configure_classifier()
+    accepted, rejected, _ = reclassify(
+        [row("2026/8/7 22:00 VRChat向け商品プレゼント。フォロー＆RPで抽選応募", retweets=20)],
+        actual_now=datetime(2026, 8, 3, tzinfo=UTC),
+        x_ids=set(),
+    )
+    assert accepted == []
+    assert rejected[0]["reason"] == "giveaway_only"
+
+
+def test_missing_datetime_remains_rejected():
+    configure_classifier()
+    accepted, rejected, _ = reclassify(
+        [row("VRChat交流イベント開催。参加方法はGroup+へJOIN", retweets=5)],
+        actual_now=datetime(2026, 8, 3, tzinfo=UTC),
+        x_ids=set(),
+    )
+    assert accepted == []
+    assert rejected[0]["reason"] == "missing_datetime"


### PR DESCRIPTION
Reclassifies the acquired Yahoo candidate database so valid past events and candidates with known retweet counts below 3 are accepted. Missing/invalid engagement, malformed identity, missing datetime, non-VRChat, commerce-only, giveaway-only, duplicate, ambiguous, and overly-future candidates remain fail-closed. Adds regression tests and a Pages deployment workflow that rewrites the generated audit/data.