### PR TITLE
Fix calendar-week relative weekday resolution

### DIFF
--- a/docs/relative-date-resolution.md
+++ b/docs/relative-date-resolution.md
@@ -1,0 +1,48 @@
+# Yahoo相対日時の解決規則
+
+Yahoo!リアルタイム検索由来の投稿は、X Snowflakeから復元した投稿日時をJSTへ変換し、その時刻を相対日時のanchorとして使用する。Snowflakeを復元できない場合のみ`first_seen_at`、それもない場合のみ実行時刻へフォールバックする。
+
+## 暦週規則
+
+週の開始は月曜日とする。
+
+| 表現 | 解決規則 |
+|---|---|
+| `今週月曜` | anchorを含む暦週の月曜。解決時刻がanchorより過去なら棄却し、次週へ繰り越さない |
+| `来週月曜` | anchorの次の暦週に属する月曜 |
+| `次の月曜` | 次に到来する月曜。同じ月曜に投稿された場合は7日後 |
+| `月曜` | 次に到来する月曜。同日で時刻が未来なら当日、2時間より前の過去時刻なら7日後 |
+| `本日` / `今日` / `明日` | anchorの日付を基準に解決 |
+| 明示年月日 | 記載された日付を使用 |
+
+`来週`は「次回出現する曜日へさらに7日加える」という計算をしない。たとえば金曜日投稿の`来週月曜`は3日後であり、10日後ではない。
+
+## 公開証跡
+
+採用イベントには次を保存する。
+
+```json
+{
+  "date_resolution_method": "next_calendar_week_weekday",
+  "date_resolution_anchor": "2026-08-07T03:00:00Z",
+  "date_resolution_evidence": {
+    "method": "next_calendar_week_weekday",
+    "anchor": "2026-08-07T03:00:00Z",
+    "resolved_at": "2026-08-10T13:00:00Z",
+    "timezone": "Asia/Tokyo",
+    "week_start": "monday",
+    "matched_text": "来週月曜 22:00"
+  }
+}
+```
+
+`public/yahoo-date-resolution-audit.json`は、前回の`data/yahoo_realtime_events.json`と再分類後のイベントを`source_id`で比較し、開始日時が変化したイベント、旧日時、新日時、解決方式、anchorを列挙する。
+
+## Fail-closed条件
+
+- `今週＋曜日`が既に過去
+- 日付または時刻を解決できない
+- 解決日時が実行時点から12時間より前
+- 解決日時が実行時点から180日より後
+
+これらは未来の日付へ推測補正せず、理由付き棄却とする。

--- a/scripts/refine_yahoo_corpus.py
+++ b/scripts/refine_yahoo_corpus.py
@@ -13,10 +13,12 @@ if __package__ in {None, ""}:
 from scripts import collect_yahoo_corpus as corpus
 from scripts import fetch_yahoo_realtime as implementation
 from scripts import run_yahoo_realtime as ledger
+from scripts.relative_datetime import build_resolution_audit, install_classifier_datetime
 
 TWITTER_EPOCH_MS = 1_288_834_974_657
 AUDIT_PATH = Path("public/yahoo-classifier-audit.json")
 POSITIVE_VOCABULARY_PATH = Path("public/yahoo-positive-vocabulary.json")
+DATE_RESOLUTION_AUDIT_PATH = Path("public/yahoo-date-resolution-audit.json")
 STRONG_GIVEAWAY_TERMS = {
     "プレゼント企画",
     "無料配布",
@@ -194,6 +196,7 @@ def build_audit(
     return {
         "schema_version": "1.3",
         "classifier_version": implementation.PARSER_VERSION,
+        "date_resolution_policy": "calendar-week-relative-date.v1",
         "generated_at": implementation.utc_text(now),
         "target_count": target,
         "candidate_count": total,
@@ -256,7 +259,9 @@ def build_positive_vocabulary(events: list[dict[str, Any]], now: datetime) -> di
 
 
 def main() -> int:
+    previous_events = implementation.read_array(implementation.OUTPUT_PATH)
     corpus.configure_classifier()
+    install_classifier_datetime(corpus, implementation)
     implementation.PARSER_VERSION = "1.8"
     now = datetime.now(UTC).replace(microsecond=0)
     history_payload = corpus.read_json(ledger.HISTORY_PATH, {})
@@ -279,6 +284,7 @@ def main() -> int:
             "generated_at": implementation.utc_text(now),
             "candidate_count": len(evaluated),
             "source_time_policy": "x_snowflake_created_at_then_first_seen_at",
+            "date_resolution_policy": "calendar-week-relative-date.v1",
             "giveaway_policy": "require_specific_event_or_vrchat_access_method",
             "candidates": evaluated,
         }
@@ -287,6 +293,14 @@ def main() -> int:
     implementation.write_json(implementation.OUTPUT_PATH, accepted)
     implementation.write_json(POSITIVE_VOCABULARY_PATH, build_positive_vocabulary(accepted, now))
     implementation.write_json(implementation.REJECTED_PATH, rejected[:2000])
+
+    generated_at = implementation.utc_text(now)
+    resolution_audit = build_resolution_audit(
+        previous_events,
+        accepted,
+        generated_at=generated_at,
+    )
+    implementation.write_json(DATE_RESOLUTION_AUDIT_PATH, resolution_audit)
 
     previous_audit = corpus.read_json(AUDIT_PATH, {})
     query_results = (
@@ -301,7 +315,7 @@ def main() -> int:
         {
             "schema_version": "2.2",
             "parser_version": implementation.PARSER_VERSION,
-            "generated_at": implementation.utc_text(now),
+            "generated_at": generated_at,
             "event_count": len(accepted),
             "history_candidate_count": len(evaluated),
             "history_accepted_count": len(accepted),
@@ -310,6 +324,13 @@ def main() -> int:
                 bool(row.get("source_created_at")) for row in evaluated
             ),
             "source_time_policy": history_payload["source_time_policy"],
+            "date_resolution_policy": history_payload["date_resolution_policy"],
+            "date_resolution_evidence_count": resolution_audit[
+                "events_with_resolution_evidence"
+            ],
+            "date_resolution_changed_event_count": resolution_audit[
+                "changed_event_count"
+            ],
             "giveaway_policy": history_payload["giveaway_policy"],
             "rejection_counts": audit["rejection_reason_counts"],
         }
@@ -318,7 +339,8 @@ def main() -> int:
     print(
         "Yahoo corpus refinement: "
         f"history={len(evaluated)} accepted={len(accepted)} rejected={len(rejected)} "
-        f"source_timestamps={health['source_timestamp_count']}"
+        f"source_timestamps={health['source_timestamp_count']} "
+        f"date_changes={resolution_audit['changed_event_count']}"
     )
     return 0
 

--- a/scripts/relative_datetime.py
+++ b/scripts/relative_datetime.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Callable
+from zoneinfo import ZoneInfo
+
+JST = ZoneInfo("Asia/Tokyo")
+WEEKDAY_INDEX = {name: index for index, name in enumerate("月火水木金土日")}
+WEEKDAY_PATTERN = re.compile(
+    r"(?P<prefix>次(?:の)?|来週(?:の)?|今週(?:の)?)?\s*"
+    r"(?P<weekday>[月火水木金土日])曜日?.{0,100}?"
+    r"(?P<hour>[01]?\d|2[0-3])(?:[:時](?P<minute>\d{2})?)",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+RELATIVE_DAY_PATTERN = re.compile(r"本日|今日|明日")
+EXPLICIT_DATE_PATTERN = re.compile(
+    r"(?:20\d{2}[./年-])?\d{1,2}[./月-]\d{1,2}日?"
+)
+
+
+@dataclass(frozen=True)
+class DateResolution:
+    event_at: datetime
+    method: str
+    anchor: datetime
+    matched_text: str
+
+    def evidence(self, utc_text: Callable[[datetime], str]) -> dict[str, str]:
+        return {
+            "method": self.method,
+            "anchor": utc_text(self.anchor),
+            "resolved_at": utc_text(self.event_at),
+            "timezone": "Asia/Tokyo",
+            "week_start": "monday",
+            "matched_text": self.matched_text,
+        }
+
+
+def _jst(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=JST)
+    return value.astimezone(JST)
+
+
+def resolve_event_datetime(
+    text: str,
+    anchor: datetime,
+    *,
+    explicit_parser: Callable[[str, datetime], datetime | None],
+) -> DateResolution | None:
+    """Resolve explicit and weekday-based event dates without future leakage.
+
+    Weekday phrases use a Monday-start calendar week. `今週` never rolls a
+    past target into the following week. `来週` resolves inside the next
+    calendar week, while `次の` and an unprefixed weekday use next-occurrence
+    semantics.
+    """
+    anchor_jst = _jst(anchor)
+    explicit = explicit_parser(text, anchor_jst)
+    if explicit is not None:
+        if RELATIVE_DAY_PATTERN.search(text):
+            method = "relative_day_from_source_timestamp"
+        elif EXPLICIT_DATE_PATTERN.search(text):
+            method = "explicit_calendar_date"
+        else:
+            method = "explicit_datetime"
+        return DateResolution(
+            event_at=_jst(explicit),
+            method=method,
+            anchor=anchor_jst,
+            matched_text="explicit",
+        )
+
+    normalized = (
+        text.replace("：", ":")
+        .replace("／", "/")
+        .replace("．", ".")
+        .replace("－", "-")
+        .replace("〜", "~")
+        .replace("～", "~")
+    )
+    match = WEEKDAY_PATTERN.search(normalized)
+    if not match:
+        return None
+
+    target_weekday = WEEKDAY_INDEX[match.group("weekday")]
+    prefix = (match.group("prefix") or "").strip()
+    hour = int(match.group("hour"))
+    minute = int(match.group("minute") or 0)
+    week_start = anchor_jst.date() - timedelta(days=anchor_jst.weekday())
+
+    if prefix.startswith("来週"):
+        target_date = week_start + timedelta(days=7 + target_weekday)
+        method = "next_calendar_week_weekday"
+    elif prefix.startswith("今週"):
+        target_date = week_start + timedelta(days=target_weekday)
+        method = "current_calendar_week_weekday"
+    else:
+        days_ahead = (target_weekday - anchor_jst.weekday()) % 7
+        if prefix.startswith("次") and days_ahead == 0:
+            days_ahead = 7
+        target_date = anchor_jst.date() + timedelta(days=days_ahead)
+        method = (
+            "next_occurrence_explicit"
+            if prefix.startswith("次")
+            else "next_occurrence_unprefixed"
+        )
+
+    resolved = datetime(
+        target_date.year,
+        target_date.month,
+        target_date.day,
+        hour,
+        minute,
+        tzinfo=JST,
+    )
+
+    if prefix.startswith("今週") and resolved < anchor_jst:
+        return None
+    if not prefix and resolved < anchor_jst - timedelta(hours=2):
+        resolved += timedelta(days=7)
+
+    return DateResolution(
+        event_at=resolved,
+        method=method,
+        anchor=anchor_jst,
+        matched_text=match.group(0)[:160],
+    )
+
+
+def install_classifier_datetime(
+    corpus: Any,
+    implementation: Any,
+) -> None:
+    """Install the corrected parser after the existing v1.8 classifier setup."""
+    explicit_parser = corpus._ORIGINAL_PARSE_EVENT_DATETIME
+    base_candidate_to_event = corpus.refined_candidate_to_event
+
+    def parse_datetime(text: str, anchor: datetime) -> datetime | None:
+        resolution = resolve_event_datetime(
+            text,
+            anchor,
+            explicit_parser=explicit_parser,
+        )
+        return resolution.event_at if resolution else None
+
+    def candidate_to_event(
+        candidate: dict[str, Any],
+        *,
+        now: datetime,
+        min_retweets: int,
+        x_ids: set[str],
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        event, reason = base_candidate_to_event(
+            candidate,
+            now=now,
+            min_retweets=min_retweets,
+            x_ids=x_ids,
+        )
+        if not event:
+            return event, reason
+        resolution = resolve_event_datetime(
+            str(candidate.get("text") or ""),
+            now,
+            explicit_parser=explicit_parser,
+        )
+        if resolution is None:
+            return None, "missing_datetime"
+        evidence = resolution.evidence(implementation.utc_text)
+        event["date_resolution_method"] = evidence["method"]
+        event["date_resolution_anchor"] = evidence["anchor"]
+        event["date_resolution_evidence"] = evidence
+        return event, reason
+
+    implementation.parse_event_datetime = parse_datetime
+    corpus.parse_event_datetime_v18 = parse_datetime
+    corpus.refined_candidate_to_event = candidate_to_event
+
+
+def build_resolution_audit(
+    previous_events: list[dict[str, Any]],
+    current_events: list[dict[str, Any]],
+    *,
+    generated_at: str,
+) -> dict[str, Any]:
+    previous_by_id = {
+        str(event.get("source_id")): event
+        for event in previous_events
+        if event.get("source_id")
+    }
+    current_by_id = {
+        str(event.get("source_id")): event
+        for event in current_events
+        if event.get("source_id")
+    }
+    changes: list[dict[str, Any]] = []
+    for source_id in sorted(previous_by_id.keys() & current_by_id.keys()):
+        previous_start = previous_by_id[source_id].get("starts_at")
+        current = current_by_id[source_id]
+        current_start = current.get("starts_at")
+        if previous_start == current_start:
+            continue
+        changes.append(
+            {
+                "source_id": source_id,
+                "previous_starts_at": previous_start,
+                "current_starts_at": current_start,
+                "date_resolution_method": current.get("date_resolution_method"),
+                "date_resolution_anchor": current.get("date_resolution_anchor"),
+            }
+        )
+
+    methods = Counter(
+        str(event.get("date_resolution_method") or "missing")
+        for event in current_events
+    )
+    return {
+        "schema_version": "1.0",
+        "policy_version": "calendar-week-relative-date.v1",
+        "generated_at": generated_at,
+        "timezone": "Asia/Tokyo",
+        "week_start": "monday",
+        "previous_event_count": len(previous_events),
+        "current_event_count": len(current_events),
+        "events_with_resolution_evidence": sum(
+            bool(event.get("date_resolution_evidence")) for event in current_events
+        ),
+        "resolution_method_counts": dict(sorted(methods.items())),
+        "changed_event_count": len(changes),
+        "changed_events": changes,
+    }

--- a/tests/test_relative_datetime.py
+++ b/tests/test_relative_datetime.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from scripts.relative_datetime import build_resolution_audit, resolve_event_datetime
+
+JST = ZoneInfo("Asia/Tokyo")
+
+
+def no_explicit_date(_text: str, _anchor: datetime) -> None:
+    return None
+
+
+def resolve(text: str, anchor: datetime):
+    return resolve_event_datetime(
+        text,
+        anchor,
+        explicit_parser=no_explicit_date,
+    )
+
+
+def test_friday_next_week_monday_is_three_days_later() -> None:
+    anchor = datetime(2026, 8, 7, 12, 0, tzinfo=JST)
+    result = resolve("来週月曜 22:00 VRChatイベント", anchor)
+    assert result is not None
+    assert result.event_at == datetime(2026, 8, 10, 22, 0, tzinfo=JST)
+    assert result.method == "next_calendar_week_weekday"
+
+
+def test_sunday_next_week_saturday_is_six_days_later() -> None:
+    anchor = datetime(2026, 8, 9, 12, 0, tzinfo=JST)
+    result = resolve("来週土曜日 21:00 開催", anchor)
+    assert result is not None
+    assert result.event_at == datetime(2026, 8, 15, 21, 0, tzinfo=JST)
+
+
+def test_monday_next_week_friday_is_eleven_days_later() -> None:
+    anchor = datetime(2026, 8, 3, 9, 0, tzinfo=JST)
+    result = resolve("来週の金曜日 20:30 OPEN", anchor)
+    assert result is not None
+    assert result.event_at == datetime(2026, 8, 14, 20, 30, tzinfo=JST)
+
+
+def test_past_current_week_weekday_is_rejected_not_rolled_forward() -> None:
+    anchor = datetime(2026, 8, 4, 12, 0, tzinfo=JST)
+    assert resolve("今週月曜 22:00 のイベント", anchor) is None
+
+
+def test_unprefixed_weekday_uses_next_occurrence() -> None:
+    anchor = datetime(2026, 8, 3, 9, 0, tzinfo=JST)
+    result = resolve("水曜 21:00 JOIN", anchor)
+    assert result is not None
+    assert result.event_at == datetime(2026, 8, 5, 21, 0, tzinfo=JST)
+    assert result.method == "next_occurrence_unprefixed"
+
+
+def test_next_same_weekday_means_seven_days_later() -> None:
+    anchor = datetime(2026, 8, 3, 9, 0, tzinfo=JST)
+    result = resolve("次の月曜 19:00 開催", anchor)
+    assert result is not None
+    assert result.event_at == datetime(2026, 8, 10, 19, 0, tzinfo=JST)
+    assert result.method == "next_occurrence_explicit"
+
+
+def test_jst_week_boundary_is_used_even_when_anchor_is_utc() -> None:
+    anchor_utc = datetime.fromisoformat("2026-08-09T14:59:00+00:00")
+    result = resolve("来週月曜 00:30 開催", anchor_utc)
+    assert result is not None
+    assert result.anchor == datetime(2026, 8, 9, 23, 59, tzinfo=JST)
+    assert result.event_at == datetime(2026, 8, 10, 0, 30, tzinfo=JST)
+
+
+def test_same_day_unprefixed_future_stays_today_and_old_time_moves_next_week() -> None:
+    anchor = datetime(2026, 8, 3, 18, 0, tzinfo=JST)
+    future = resolve("月曜 21:00 開催", anchor)
+    old = resolve("月曜 12:00 開催", anchor)
+    assert future is not None and future.event_at.date() == anchor.date()
+    assert old is not None and old.event_at.date().isoformat() == "2026-08-10"
+
+
+def test_resolution_audit_records_changed_existing_events() -> None:
+    previous = [
+        {
+            "source_id": "yahoo:x:1",
+            "starts_at": "2026-08-17T13:00:00Z",
+        }
+    ]
+    current = [
+        {
+            "source_id": "yahoo:x:1",
+            "starts_at": "2026-08-10T13:00:00Z",
+            "date_resolution_method": "next_calendar_week_weekday",
+            "date_resolution_anchor": "2026-08-07T03:00:00Z",
+            "date_resolution_evidence": {"method": "next_calendar_week_weekday"},
+        }
+    ]
+    audit = build_resolution_audit(
+        previous,
+        current,
+        generated_at="2026-08-03T00:00:00Z",
+    )
+    assert audit["changed_event_count"] == 1
+    assert audit["events_with_resolution_evidence"] == 1
+    assert audit["changed_events"][0]["previous_starts_at"] == "2026-08-17T13:00:00Z"
+    assert audit["changed_events"][0]["current_starts_at"] == "2026-08-10T13:00:00Z"


### PR DESCRIPTION
## Summary

- resolve `来週` against the next Monday-start calendar week instead of adding seven days to the next occurrence
- resolve `今週` inside the current calendar week and fail closed when the target is already past
- keep separate semantics for `次の` and unprefixed weekdays
- anchor all relative dates to the restored X source timestamp in JST
- attach the resolution method, anchor, resolved timestamp, timezone, and matched text to accepted events
- publish an audit comparing prior and recalculated event start times
- add regression tests for all reported boundary examples, JST/UTC transitions, same-day times, and audit changes

Closes #20.
