### PR TITLE
Verify issue 20 and remove merged branches

### DIFF
--- a/.github/workflows/verify-issue-20-cleanup.yml
+++ b/.github/workflows/verify-issue-20-cleanup.yml
@@ -1,0 +1,30 @@
+name: Verify issue 20 and cleanup branches
+on:
+  push:
+    branches: [main]
+    paths: [.github/workflows/verify-issue-20-cleanup.yml]
+permissions:
+  contents: write
+jobs:
+  verify-and-cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with: {fetch-depth: 0}
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.12'}
+      - run: python -m pip install --disable-pip-version-check pytest
+      - run: python -m pytest tests/test_relative_datetime.py -q
+      - name: Delete merged work branches
+        run: |
+          for branch in agent/fix-relative-weekday-resolution agent/fix-relative-weekday-resolution-v2 ops/finalize-issue-20; do git push origin --delete "$branch" || true; done
+      - name: Remove one-time workflow
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git fetch origin main
+          git checkout -B main origin/main
+          git rm .github/workflows/verify-issue-20-cleanup.yml
+          git commit -m 'chore: remove issue 20 verification workflow [skip ci]'
+          git push origin HEAD:main


### PR DESCRIPTION
Runs the JST calendar-week regression tests, deletes both implementation branches and the finalizer branch, then removes the one-time workflow.