### PR TITLE
Fix first-view visual hierarchy after production screenshot audit

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -17,7 +17,7 @@ export async function onRequest(context) {
 
   const transformed = new HTMLRewriter().on('head', new HeadAssets()).transform(response);
   const headers = new Headers(transformed.headers);
-  headers.set('x-quality-view', '2026-08-03-quality-view-v4');
+  headers.set('x-quality-view', '2026-08-04-quality-view-v5');
   return new Response(transformed.body, {
     status: transformed.status,
     statusText: transformed.statusText,

--- a/public/uiux-v4.css
+++ b/public/uiux-v4.css
@@ -1,1 +1,242 @@
-:root{--q-bg:#f4f7fb;--q-surface:rgba(255,255,255,.94);--q-ink:#17243a;--q-muted:#64728a;--q-line:#d9e1ed;--q-accent:#4057c7;--q-accent-2:#238262;--q-soft:#edf1ff;--q-shadow:0 16px 44px rgba(40,55,90,.11);--q-shadow-sm:0 7px 22px rgba(40,55,90,.075)}*{scrollbar-color:#b7c3d6 transparent}html{scroll-padding-top:94px}body{background:radial-gradient(circle at 5% -8%,rgba(91,117,224,.2),transparent 34rem),radial-gradient(circle at 98% 8%,rgba(65,181,144,.12),transparent 30rem),var(--q-bg);color:var(--q-ink)}.skip-link{position:fixed;left:10px;top:10px;z-index:100;padding:10px 14px;border-radius:10px;background:var(--q-ink);color:#fff;text-decoration:none;transform:translateY(-160%)}.skip-link:focus{transform:none}.shell{width:min(1280px,100%);padding-top:clamp(14px,2.5vw,30px)}.hero{position:relative;overflow:hidden;align-items:center;margin-bottom:14px;padding:clamp(24px,4vw,46px);border:1px solid var(--q-line);border-radius:30px;background:linear-gradient(125deg,rgba(255,255,255,.98),rgba(241,245,255,.91));box-shadow:var(--q-shadow)}.hero:after{content:"";position:absolute;right:-90px;bottom:-130px;width:340px;height:340px;border-radius:50%;background:linear-gradient(145deg,rgba(64,87,199,.18),rgba(35,130,98,.07));pointer-events:none}.hero>*{position:relative;z-index:1}.eyebrow{color:var(--q-accent);letter-spacing:.11em}h1{max-width:780px;margin-top:.55rem;font-size:clamp(2.2rem,6vw,4.75rem);line-height:.98}.lede{max-width:730px;color:var(--q-muted);line-height:1.72}.ux-data-menu{justify-self:end}.ux-data-menu summary{display:inline-flex;min-height:44px;align-items:center;padding:9px 14px;border:1px solid var(--q-line);border-radius:999px;background:#fff;color:var(--q-muted);font-size:.78rem;font-weight:800;cursor:pointer;list-style:none}.ux-data-menu summary::-webkit-details-marker{display:none}.ux-data-menu .hero-actions{max-width:360px;margin-top:9px;justify-content:flex-end}.ux-data-menu .button{min-height:38px;padding:7px 11px;font-size:.75rem}.ux-command{position:sticky;top:8px;z-index:14;display:grid;grid-template-columns:minmax(0,1fr) auto;gap:12px;align-items:center;margin-bottom:14px;padding:11px 13px;border:1px solid var(--q-line);border-radius:19px;background:rgba(248,250,254,.9);box-shadow:var(--q-shadow-sm);backdrop-filter:blur(18px)}.ux-next{display:flex;min-width:0;align-items:center;gap:10px}.ux-live{display:inline-flex;align-items:center;gap:6px;color:var(--q-accent-2);font-size:.67rem;font-weight:900;letter-spacing:.09em}.ux-live:before{content:"";width:8px;height:8px;border-radius:50%;background:#2a9d76;box-shadow:0 0 0 5px rgba(42,157,118,.12)}.ux-next-copy{min-width:0}.ux-next-copy strong,.ux-next-copy span{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.ux-next-copy strong{font-size:.86rem}.ux-next-copy span{margin-top:2px;color:var(--q-muted);font-size:.72rem}.ux-actions{display:flex;gap:7px;flex-wrap:wrap;justify-content:flex-end}.ux-action,.ux-density,.ux-reset{min-height:42px;padding:8px 12px;border:1px solid var(--q-line);border-radius:999px;background:#fff;color:var(--q-ink);font-weight:800;cursor:pointer}.ux-action[data-primary=true]{border-color:var(--q-accent);background:var(--q-accent);color:#fff}.summary{gap:10px;margin-bottom:14px}.metric{padding:15px 16px;border-color:var(--q-line);background:var(--q-surface);box-shadow:var(--q-shadow-sm)}.metric[data-ux-range]{cursor:pointer}.metric[data-ux-range]:hover{border-color:#aab8d2;transform:translateY(-1px)}.controls{position:relative;top:auto;border-color:var(--q-line);background:var(--q-surface);box-shadow:var(--q-shadow-sm)}input[type=search],select{min-height:48px;border-color:var(--q-line);background:#fff}input[type=search]:focus,select:focus{border-color:var(--q-accent);outline:3px solid rgba(64,87,199,.14)}.chip,.button,.event-link,.secondary-button{min-height:42px}.chip[aria-pressed=true],.button.primary,.event-link.primary{border-color:var(--q-accent);background:var(--q-accent);color:#fff}.ux-reset{padding-inline:11px;color:var(--q-muted);font-size:.77rem}.day{grid-template-columns:110px minmax(0,1fr);gap:14px}.day-label{top:88px}.event{grid-template-columns:76px minmax(0,1fr) minmax(140px,190px);gap:14px;padding:15px;border-color:var(--q-line);border-radius:20px;background:rgba(255,255,255,.95);box-shadow:var(--q-shadow-sm);transition:.15s ease}.event:hover,.event:focus-within{border-color:#a7b5cf;box-shadow:0 14px 34px rgba(40,55,90,.12);transform:translateY(-1px)}.time{padding-top:2px;color:var(--q-accent);font-size:1.07rem}.event-main:after{display:block;clear:both;content:""}.event-media-link{float:right;width:min(245px,38%);margin:0 0 10px 14px!important;border-radius:14px!important}.event-media{border:0!important;border-radius:14px}.event h2{margin-top:8px;color:var(--q-ink);font-size:1.08rem}.description{-webkit-line-clamp:2;color:#46556d}.details{grid-template-columns:repeat(2,minmax(0,1fr))}.detail{background:#f4f6fa}.event-links{align-self:stretch;display:flex;flex-direction:column;justify-content:center;max-width:none}.event-link{width:100%}.event-link.primary:after{margin-left:5px;content:"↗"}body:not(.ux-detailed) .details,body:not(.ux-detailed) .tags{display:none}body.ux-detailed .description{-webkit-line-clamp:4}.recommendations{scroll-margin-top:90px;border-color:#aebcdc!important;background:linear-gradient(135deg,rgba(255,255,255,.97),rgba(237,241,255,.9))!important}.recommendation-card{border-color:var(--q-line)!important;box-shadow:var(--q-shadow-sm)}.ux-mobile-nav{display:none}.ux-back-top{position:fixed;right:18px;bottom:18px;z-index:20;width:44px;height:44px;border:1px solid var(--q-line);border-radius:50%;background:#fff;color:var(--q-ink);box-shadow:var(--q-shadow-sm);opacity:0;pointer-events:none}.ux-back-top[data-visible=true]{opacity:1;pointer-events:auto}:where(button,a,input,select,summary):focus-visible{outline:3px solid rgba(64,87,199,.28);outline-offset:2px}@media(max-width:920px){.ux-command{grid-template-columns:1fr}.ux-actions{justify-content:flex-start}.event{grid-template-columns:68px minmax(0,1fr)}.event-links{grid-column:2;flex-direction:row;justify-content:flex-start}.event-link{width:auto}}@media(max-width:820px){.hero{border-radius:24px}.ux-data-menu{justify-self:start}.ux-data-menu .hero-actions{justify-content:flex-start}.ux-command{position:static}.day{grid-template-columns:1fr}.event-media-link{width:min(220px,42%)}}@media(max-width:600px){.shell{padding-inline:12px;padding-bottom:104px}.hero{padding:22px 18px}h1{font-size:clamp(2.1rem,13vw,3.4rem)}.lede{font-size:.94rem}.ux-actions{display:none}.summary{grid-template-columns:repeat(2,minmax(0,1fr))}.controls{padding:12px}.chips{flex-wrap:nowrap;width:100%;overflow-x:auto;padding-bottom:4px}.chip{flex:0 0 auto}.event{grid-template-columns:1fr;gap:8px;padding:13px}.time{display:flex;align-items:baseline;gap:6px}.time small{display:inline;margin:0}.event-media-link{float:none;width:100%;margin:0 0 12px!important}.event-links{grid-column:1;display:grid;grid-template-columns:repeat(2,minmax(0,1fr))}.event-link{width:100%}.ux-mobile-nav{position:fixed;right:10px;bottom:10px;left:10px;z-index:30;display:grid;grid-template-columns:repeat(4,minmax(0,1fr));padding:7px;border:1px solid var(--q-line);border-radius:19px;background:rgba(255,255,255,.95);box-shadow:0 18px 44px rgba(40,55,90,.22);backdrop-filter:blur(18px)}.ux-mobile-nav button{min-height:48px;border:0;border-radius:13px;background:transparent;color:var(--q-muted);font-size:.69rem;font-weight:850}.ux-mobile-nav button[data-active=true]{background:var(--q-soft);color:var(--q-accent)}.ux-back-top{display:none}}@media(prefers-color-scheme:dark){:root{--q-bg:#111722;--q-surface:rgba(25,34,49,.94);--q-ink:#eef3fb;--q-muted:#a8b4c8;--q-line:#344056;--q-accent:#8799ff;--q-soft:rgba(111,130,239,.18);--q-shadow:0 18px 50px rgba(0,0,0,.28);--q-shadow-sm:0 8px 24px rgba(0,0,0,.2)}body{background:radial-gradient(circle at 5% -8%,rgba(111,133,235,.18),transparent 34rem),var(--q-bg)}.hero{background:linear-gradient(125deg,rgba(28,38,55,.98),rgba(22,30,45,.96))}.metric,.controls,.event,.recommendation-card,.ux-command,.ux-mobile-nav,.ux-back-top{background-color:#1a2332!important}input[type=search],select,.chip,.button,.event-link,.secondary-button,.ux-action,.ux-density,.ux-reset,.ux-data-menu summary{border-color:var(--q-line);background:#202b3d;color:var(--q-ink)}.detail,.tag,.badge.mode{background:#242f42;color:#cbd5e5}.description,.meta{color:var(--q-muted)}}@media(prefers-reduced-motion:reduce){*,*:before,*:after{scroll-behavior:auto!important;transition-duration:.01ms!important;animation-duration:.01ms!important}}
+:root{
+  --q-bg:#f4f6fa;
+  --q-surface:#ffffff;
+  --q-ink:#152238;
+  --q-muted:#627086;
+  --q-line:#d9e0eb;
+  --q-accent:#3656d4;
+  --q-accent-strong:#2945bd;
+  --q-accent-2:#168263;
+  --q-soft:#eef2ff;
+  --q-shadow:0 14px 36px rgba(38,53,85,.09);
+  --q-shadow-sm:0 5px 16px rgba(38,53,85,.065);
+}
+*{scrollbar-color:#b7c2d4 transparent}
+html{scroll-padding-top:82px}
+body{
+  background:radial-gradient(circle at 7% -10%,rgba(75,103,218,.14),transparent 30rem),var(--q-bg);
+  color:var(--q-ink);
+}
+.skip-link{
+  position:fixed;left:10px;top:10px;z-index:100;padding:10px 14px;border-radius:10px;
+  background:var(--q-ink);color:#fff;text-decoration:none;transform:translateY(-160%);
+}
+.skip-link:focus{transform:none}
+.shell{
+  display:flex;flex-direction:column;width:min(1240px,100%);margin:auto;
+  padding:16px clamp(14px,2.5vw,28px) 64px;
+}
+.hero{order:1}
+.ux-command{order:2}
+.summary{order:3}
+.controls{order:4}
+.statusbar{order:5}
+.agenda{order:6}
+.ux-load-more{order:6}
+.recommendations{order:7}
+footer{order:8}
+.hero{
+  position:relative;overflow:hidden;display:grid;grid-template-columns:minmax(0,1fr) auto;
+  gap:18px;align-items:center;margin:0 0 10px;padding:22px 26px;
+  border:1px solid var(--q-line);border-radius:23px;
+  background:linear-gradient(125deg,#fff 0%,#f3f6ff 100%);box-shadow:var(--q-shadow);
+}
+.hero:after{
+  content:"";position:absolute;right:-54px;bottom:-88px;width:220px;height:220px;border-radius:50%;
+  background:linear-gradient(145deg,rgba(54,86,212,.14),rgba(22,130,99,.05));pointer-events:none;
+}
+.hero>*{position:relative;z-index:1}
+.eyebrow{color:var(--q-accent);font-size:.72rem;letter-spacing:.11em}
+h1{
+  max-width:760px;margin:.35rem 0 .45rem;font-size:clamp(2rem,4.2vw,3.45rem);
+  line-height:1;letter-spacing:-.045em;
+}
+.lede{max-width:700px;margin:0;color:var(--q-muted);font-size:.96rem;line-height:1.62}
+.ux-data-menu{justify-self:end}
+.ux-data-menu summary{
+  display:inline-flex;min-height:38px;align-items:center;padding:7px 12px;border:1px solid var(--q-line);
+  border-radius:999px;background:#fff;color:var(--q-muted);font-size:.73rem;font-weight:800;
+  cursor:pointer;list-style:none;
+}
+.ux-data-menu summary::-webkit-details-marker{display:none}
+.ux-data-menu .hero-actions{max-width:340px;margin-top:8px;justify-content:flex-end}
+.ux-data-menu .button{min-height:36px;padding:6px 10px;font-size:.72rem}
+.ux-command{
+  position:sticky;top:7px;z-index:14;display:grid;grid-template-columns:minmax(0,1fr) auto;
+  gap:10px;align-items:center;margin:0 0 10px;padding:8px 10px;border:1px solid var(--q-line);
+  border-radius:16px;background:rgba(249,250,253,.94);box-shadow:var(--q-shadow-sm);backdrop-filter:blur(16px);
+}
+.ux-next{display:flex;min-width:0;align-items:center;gap:9px}
+.ux-live{display:inline-flex;flex:0 0 auto;align-items:center;gap:6px;color:var(--q-accent-2);font-size:.64rem;font-weight:900;letter-spacing:.08em}
+.ux-live:before{content:"";width:7px;height:7px;border-radius:50%;background:#229b76;box-shadow:0 0 0 4px rgba(34,155,118,.11)}
+.ux-next-copy{min-width:0}
+.ux-next-copy strong,.ux-next-copy span{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.ux-next-copy strong{font-size:.84rem}
+.ux-next-copy span{margin-top:1px;color:var(--q-muted);font-size:.69rem}
+.ux-actions{display:flex;gap:6px;flex-wrap:nowrap;justify-content:flex-end}
+.ux-action,.ux-density,.ux-reset,.ux-filter-toggle,.ux-load-more{
+  min-height:38px;padding:7px 11px;border:1px solid var(--q-line);border-radius:999px;
+  background:#fff;color:var(--q-ink);font-weight:800;cursor:pointer;
+}
+.ux-action[data-primary=true]{border-color:var(--q-accent);background:var(--q-accent);color:#fff}
+.summary{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:8px;margin:0 0 10px}
+.metric{
+  min-width:0;display:flex;align-items:baseline;gap:9px;padding:9px 12px;border-color:var(--q-line);
+  border-radius:15px;background:var(--q-surface);box-shadow:var(--q-shadow-sm);
+}
+.metric b{font-size:clamp(1.2rem,2.5vw,1.55rem);line-height:1}
+.metric span{margin:0;color:var(--q-muted);font-size:.72rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.metric[data-ux-range]{cursor:pointer}
+.metric[data-ux-range]:hover{border-color:#aab7d0;transform:translateY(-1px)}
+.controls{
+  position:relative;top:auto;margin:0;padding:11px;border-color:var(--q-line);border-radius:18px;
+  background:var(--q-surface);box-shadow:var(--q-shadow-sm);
+}
+.search-row{grid-template-columns:minmax(0,2fr) repeat(2,minmax(145px,.7fr));gap:8px}
+.field{gap:4px}
+.field label{font-size:.68rem}
+input[type=search],select{min-height:42px;border-color:var(--q-line);border-radius:12px;background:#fff;padding:8px 11px}
+input[type=search]:focus,select:focus{border-color:var(--q-accent);outline:3px solid rgba(54,86,212,.13)}
+.filter-row{margin-top:8px;gap:8px}
+.chips{gap:5px}
+.chip,.button,.event-link,.secondary-button{min-height:38px;padding:7px 11px}
+.chip[aria-pressed=true],.button.primary,.event-link.primary{border-color:var(--q-accent);background:var(--q-accent);color:#fff}
+.ux-reset{padding-inline:10px;color:var(--q-muted);font-size:.73rem}
+.ux-filter-toggle{display:none}
+.statusbar{margin:11px 2px 7px;font-size:.82rem}
+.agenda{display:grid;gap:14px}
+.day{grid-template-columns:100px minmax(0,1fr);gap:12px}
+.day-label{top:80px;padding-top:9px}
+.events{gap:8px}
+.event{
+  grid-template-columns:70px minmax(0,1fr) minmax(132px,176px);gap:12px;align-items:start;
+  padding:13px;border-color:var(--q-line);border-radius:17px;background:rgba(255,255,255,.97);
+  box-shadow:var(--q-shadow-sm);transition:.15s ease;
+}
+.event[hidden]{display:none!important}
+.event:hover,.event:focus-within{border-color:#a7b4cf;box-shadow:0 12px 28px rgba(38,53,85,.105);transform:translateY(-1px)}
+.time{padding-top:2px;color:var(--q-accent);font-size:1rem}
+.event-main:after{display:block;clear:both;content:""}
+.event-media-link{float:right;width:min(220px,35%);margin:0 0 9px 12px!important;border-radius:12px!important}
+.event-media{border:0!important;border-radius:12px}
+.event h2{margin:7px 0 4px;color:var(--q-ink);font-size:1rem;line-height:1.42}
+.description{-webkit-line-clamp:2;color:#46556d;font-size:.83rem}
+.details{grid-template-columns:repeat(2,minmax(0,1fr))}
+.detail{padding:7px 8px;background:#f4f6fa}
+.tags{margin-top:8px}
+.event-links{align-self:stretch;display:flex;flex-direction:column;justify-content:center;max-width:none}
+.event-link{width:100%;font-size:.75rem}
+.event-link.primary:after{margin-left:4px;content:"↗"}
+body:not(.ux-detailed) .details,body:not(.ux-detailed) .tags{display:none}
+body.ux-detailed .description{-webkit-line-clamp:4}
+.ux-load-more{
+  align-self:center;margin:15px auto 3px;padding-inline:20px;border-color:#aebada;color:var(--q-accent);
+}
+.recommendations{
+  margin:24px 0 0!important;padding:16px!important;scroll-margin-top:82px;
+  border-color:#b7c2dc!important;border-radius:20px!important;
+  background:linear-gradient(135deg,#fff,#f1f4ff)!important;box-shadow:var(--q-shadow-sm)!important;
+}
+.recommendations-head{gap:12px}
+.recommendations h2{font-size:clamp(1.3rem,2.5vw,1.75rem)}
+.recommendations-description{font-size:.8rem;line-height:1.5}
+.history-summary{margin:10px 0 9px}
+.recommendation-grid{
+  display:grid!important;grid-auto-flow:column;grid-auto-columns:minmax(280px,315px);grid-template-columns:none!important;
+  gap:9px;overflow-x:auto;padding:2px 2px 7px;scroll-snap-type:x proximity;overscroll-behavior-inline:contain;
+}
+.recommendation-card{min-height:220px;border-color:var(--q-line)!important;border-radius:15px!important;padding:12px!important;box-shadow:none!important;scroll-snap-align:start}
+.recommendation-card h3{font-size:.92rem}
+.ux-mobile-nav{display:none!important}
+.ux-back-top{
+  position:fixed;right:18px;bottom:18px;z-index:20;width:42px;height:42px;border:1px solid var(--q-line);
+  border-radius:50%;background:#fff;color:var(--q-ink);box-shadow:var(--q-shadow-sm);opacity:0;pointer-events:none;
+}
+.ux-back-top[data-visible=true]{opacity:1;pointer-events:auto}
+:where(button,a,input,select,summary):focus-visible{outline:3px solid rgba(54,86,212,.25);outline-offset:2px}
+@media(max-width:920px){
+  .ux-command{grid-template-columns:1fr}
+  .ux-actions{justify-content:flex-start}
+  .event{grid-template-columns:64px minmax(0,1fr)}
+  .event-links{grid-column:2;flex-direction:row;justify-content:flex-start}
+  .event-link{width:auto}
+}
+@media(max-width:820px){
+  .hero{grid-template-columns:1fr;border-radius:20px}
+  .ux-data-menu{justify-self:start}
+  .ux-data-menu .hero-actions{justify-content:flex-start}
+  .ux-command{position:static}
+  .day{grid-template-columns:1fr;gap:6px}
+  .day-label{position:static;padding:5px 2px 0}
+  .event-media-link{width:min(210px,40%)}
+}
+@media(max-width:600px){
+  html{scroll-padding-top:8px}
+  .shell{padding:8px 10px 52px}
+  .hero{gap:8px;margin-bottom:8px;padding:16px 15px;border-radius:19px}
+  .hero:after{right:-65px;bottom:-90px;width:185px;height:185px}
+  .eyebrow{font-size:.65rem}
+  h1{margin:.25rem 0 .35rem;font-size:clamp(2rem,11vw,2.65rem);line-height:1.02}
+  .lede{max-width:290px;font-size:.82rem;line-height:1.5;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+  .ux-data-menu summary{min-height:34px;padding:6px 10px}
+  .ux-data-menu .hero-actions{display:none}
+  .ux-data-menu[open] .hero-actions{display:flex}
+  .ux-command{position:sticky;top:5px;gap:7px;margin-bottom:8px;padding:7px;border-radius:14px}
+  .ux-next{padding:0 3px}
+  .ux-live{font-size:.6rem}
+  .ux-next-copy strong{font-size:.79rem}
+  .ux-next-copy span{font-size:.64rem}
+  .ux-actions{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));width:100%;gap:5px}
+  .ux-action{min-height:36px;padding:5px 4px;font-size:.68rem}
+  .ux-density{display:none}
+  .summary{grid-template-columns:repeat(4,minmax(0,1fr));gap:5px;margin-bottom:8px}
+  .metric{display:block;padding:8px 7px;border-radius:13px;text-align:center}
+  .metric b{display:block;font-size:1.18rem}
+  .metric span{display:block;margin-top:3px;font-size:.59rem}
+  .controls{padding:9px;border-radius:16px}
+  .search-row{grid-template-columns:1fr}
+  .search-row .field:nth-child(n+2),.filter-row{display:none}
+  .controls.ux-filters-open .search-row .field:nth-child(n+2),.controls.ux-filters-open .filter-row{display:flex}
+  .controls.ux-filters-open .search-row .field:nth-child(n+2){display:grid}
+  .controls.ux-filters-open .filter-row{align-items:flex-start}
+  .ux-filter-toggle{display:inline-flex;align-items:center;justify-content:center;width:100%;margin-top:7px;min-height:38px;font-size:.72rem}
+  .chips{flex-wrap:nowrap;width:100%;overflow-x:auto;padding-bottom:3px}
+  .chip{flex:0 0 auto}
+  .toggle{font-size:.76rem}
+  .statusbar{margin:9px 2px 6px;font-size:.76rem}
+  .agenda{gap:11px}
+  .event{grid-template-columns:1fr;gap:7px;padding:11px;border-radius:15px}
+  .time{display:flex;align-items:baseline;gap:5px;font-size:.94rem}
+  .time small{display:inline;margin:0}
+  .event-media-link{float:none;width:100%;margin:0 0 9px!important}
+  .event h2{font-size:.96rem}
+  .event-links{grid-column:1;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px}
+  .event-link{width:100%;min-height:40px}
+  .ux-load-more{width:100%;margin-top:10px}
+  .recommendations{margin-top:18px!important;padding:13px!important}
+  .recommendations-head .secondary-button{min-height:34px}
+  .privacy-note{font-size:.68rem}
+  .history-summary{display:none}
+  .recommendation-grid{grid-auto-columns:min(82vw,305px)}
+  .recommendation-card{min-height:205px}
+  .ux-back-top{display:none}
+}
+@media(prefers-color-scheme:dark){
+  :root{
+    --q-bg:#111722;--q-surface:#192231;--q-ink:#eef3fb;--q-muted:#a8b4c8;--q-line:#344056;
+    --q-accent:#8295ff;--q-accent-strong:#9babff;--q-soft:rgba(111,130,239,.18);
+    --q-shadow:0 18px 50px rgba(0,0,0,.28);--q-shadow-sm:0 8px 24px rgba(0,0,0,.2);
+  }
+  body{background:radial-gradient(circle at 5% -8%,rgba(111,133,235,.16),transparent 30rem),var(--q-bg)}
+  .hero{background:linear-gradient(125deg,#1c2637,#161e2d)}
+  .metric,.controls,.event,.recommendation-card,.ux-command,.ux-back-top{background-color:#1a2332!important}
+  input[type=search],select,.chip,.button,.event-link,.secondary-button,.ux-action,.ux-density,.ux-reset,.ux-filter-toggle,.ux-load-more,.ux-data-menu summary{
+    border-color:var(--q-line);background:#202b3d;color:var(--q-ink)
+  }
+  .detail,.tag,.badge.mode{background:#242f42;color:#cbd5e5}
+  .description,.meta{color:var(--q-muted)}
+  .recommendations{background:linear-gradient(135deg,#1a2332,#182033)!important}
+}
+@media(prefers-reduced-motion:reduce){
+  *,*:before,*:after{scroll-behavior:auto!important;transition-duration:.01ms!important;animation-duration:.01ms!important}
+}

--- a/public/uiux-v4.js
+++ b/public/uiux-v4.js
@@ -1,1 +1,278 @@
-(()=>{'use strict'; const VERSION='2026-08-03-quality-view-v4',DETAIL_KEY='vrc-event-detailed-view-v1'; const $=(s,r=document)=>r.querySelector(s),$$=(s,r=document)=>[...r.querySelectorAll(s)]; const make=(tag,cls,text)=>{const el=document.createElement(tag);if(cls)el.className=cls;if(text)el.textContent=text;return el}; const scrollToEl=el=>el?.scrollIntoView({behavior:'smooth',block:'start'}); function currentRange(){return $('.chip[data-range][aria-pressed=true]')?.dataset.range||'week'} function updateMobile(range){$$('.ux-mobile-nav [data-range-target]').forEach(b=>b.dataset.active=String(b.dataset.rangeTarget===range))} function selectRange(range,scroll=true){const chip=$(`.chip[data-range="${range}"]`);if(!chip)return;chip.click();updateMobile(range);if(scroll)scrollToEl($('.statusbar'))} function hero(){const root=$('.hero');if(!root)return;const eye=$('.eyebrow',root),title=$('h1',root),lede=$('.lede',root),actions=$('.hero-actions',root);if(eye)eye.textContent='LIVE EVENT DISCOVERY · JST';if(title)title.textContent='今夜のVRChatイベント';if(lede)lede.textContent='開催時刻、ジャンル、参加方法を一画面で比較。公式リンクへ最短で進み、気になるイベントは端末内の閲覧履歴から次回おすすめに反映されます。';if(actions&&!$('.ux-data-menu',root)){const d=make('details','ux-data-menu'),s=make('summary','','データ・監査');actions.replaceWith(d);d.append(s,actions)}} function command(){if($('.ux-command')||!$('.hero'))return;const bar=make('section','ux-command');bar.setAttribute('aria-label','クイック操作');bar.innerHTML='<div class="ux-next" aria-live="polite"><span class="ux-live">UPCOMING</span><span class="ux-next-copy"><strong id="ux-next-title">イベントを読み込み中</strong><span id="ux-next-meta">開催情報を確認しています</span></span></div><div class="ux-actions"><button class="ux-action" data-ux="today" data-primary="true">今日</button><button class="ux-action" data-ux="week">7日間</button><button class="ux-action" data-ux="recommend">おすすめ</button><button class="ux-action" data-ux="search">検索</button><button class="ux-density" data-ux="density">詳細表示</button></div>';$('.hero').after(bar);bar.addEventListener('click',e=>{const a=e.target.closest('[data-ux]')?.dataset.ux;if(a==='today'||a==='week')selectRange(a);if(a==='recommend')scrollToEl($('#recommendations'));if(a==='search'){scrollToEl($('.controls'));setTimeout(()=>$('#q')?.focus(),220)}if(a==='density')density()})} function reset(){const row=$('.filter-row');if(!row||$('.ux-reset',row))return;const b=make('button','ux-reset','条件をリセット');b.type='button';b.onclick=()=>{for(const [id,val] of [['q',''],['category','all'],['source','all']]){const el=$(`#${id}`);if(el){el.value=val;el.dispatchEvent(new Event(id==='q'?'input':'change',{bubbles:true}))}}const d=$('#include-deadlines');if(d){d.checked=false;d.dispatchEvent(new Event('change',{bubbles:true}))}selectRange('week',false)};row.append(b)} function metrics(){for(const [id,range] of [['metric-today','today'],['metric-week','week'],['metric-total','all']]){const m=$(`#${id}`)?.closest('.metric');if(!m||m.dataset.uxRange)continue;m.dataset.uxRange=range;m.tabIndex=0;m.setAttribute('role','button');m.setAttribute('aria-label',`${m.textContent.trim()}を表示`);const run=()=>selectRange(range);m.onclick=run;m.onkeydown=e=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();run()}}}} function density(force){const next=typeof force==='boolean'?force:!document.body.classList.contains('ux-detailed');document.body.classList.toggle('ux-detailed',next);try{localStorage.setItem(DETAIL_KEY,next?'1':'0')}catch{}$$('.ux-density').forEach(b=>{b.textContent=next?'標準表示':'詳細表示';b.setAttribute('aria-pressed',String(next))})} function mobile(){if($('.ux-mobile-nav'))return;const nav=make('nav','ux-mobile-nav');nav.setAttribute('aria-label','モバイル用ナビゲーション');nav.innerHTML='<button data-range-target="today">今日</button><button data-range-target="week">7日</button><button data-mobile="recommend">おすすめ</button><button data-mobile="search">検索</button>';document.body.append(nav);updateMobile(currentRange());nav.onclick=e=>{const b=e.target.closest('button');if(!b)return;if(b.dataset.rangeTarget)selectRange(b.dataset.rangeTarget);if(b.dataset.mobile==='recommend')scrollToEl($('#recommendations'));if(b.dataset.mobile==='search'){scrollToEl($('.controls'));setTimeout(()=>$('#q')?.focus(),220)}}} function topButton(){if($('.ux-back-top'))return;const b=make('button','ux-back-top','↑');b.type='button';b.setAttribute('aria-label','ページ先頭へ戻る');b.dataset.visible='false';b.onclick=()=>window.scrollTo({top:0,behavior:'smooth'});document.body.append(b);addEventListener('scroll',()=>b.dataset.visible=String(scrollY>720),{passive:true})} function enhance(){const first=$('.event'),title=$('#ux-next-title'),meta=$('#ux-next-meta');$$('.event').forEach(card=>{if(card.dataset.uxEnhanced===VERSION)return;card.dataset.uxEnhanced=VERSION;const name=$('h2',card)?.textContent.trim();if(name)card.setAttribute('aria-label',name);$$('.event-link',card).forEach((a,i)=>{if(i===0)a.setAttribute('aria-label',`${name||'イベント'}の公式情報を開く`)})});if(!title||!meta)return;if(!first){title.textContent='条件に合うイベントはありません';meta.textContent='期間または絞り込み条件を変更してください';return}title.textContent=$('h2',first)?.textContent.trim()||'次のイベント';meta.textContent=[first.closest('.day')?.querySelector('.day-label strong')?.textContent.trim(),$('.time',first)?.textContent.replace(/\s+/g,' ').trim()].filter(Boolean).join(' · ')} function observe(){const a=$('#agenda');if(!a)return;new MutationObserver(enhance).observe(a,{childList:true,subtree:true});enhance()} function keyboard(){addEventListener('keydown',e=>{const editing=e.target instanceof HTMLInputElement||e.target instanceof HTMLSelectElement||e.target instanceof HTMLTextAreaElement;if(e.key==='/'&&!editing){e.preventDefault();scrollToEl($('.controls'));$('#q')?.focus()}if(editing||e.ctrlKey||e.metaKey||e.altKey)return;if(e.key.toLowerCase()==='t')selectRange('today');if(e.key.toLowerCase()==='w')selectRange('week');if(e.key.toLowerCase()==='r')scrollToEl($('#recommendations'))})} function start(){document.documentElement.dataset.qualityView=VERSION;if(!$('.skip-link')){const l=make('a','skip-link','イベント一覧へ移動');l.href='#agenda';document.body.prepend(l)}hero();command();reset();metrics();let detailed=false;try{detailed=localStorage.getItem(DETAIL_KEY)==='1'}catch{}density(detailed);mobile();topButton();observe();keyboard();$$('.chip[data-range]').forEach(c=>c.addEventListener('click',()=>updateMobile(c.dataset.range)))} document.readyState==='loading'?document.addEventListener('DOMContentLoaded',start,{once:true}):start(); })();
+(()=>{
+  'use strict';
+
+  const VERSION='2026-08-04-quality-view-v5';
+  const DETAIL_KEY='vrc-event-detailed-view-v1';
+  const $=(selector,root=document)=>root.querySelector(selector);
+  const $$=(selector,root=document)=>[...root.querySelectorAll(selector)];
+  const make=(tag,className,text)=>{
+    const element=document.createElement(tag);
+    if(className) element.className=className;
+    if(text) element.textContent=text;
+    return element;
+  };
+  const scrollToEl=element=>element?.scrollIntoView({behavior:'smooth',block:'start'});
+
+  let pageLimit=defaultPageLimit();
+
+  function defaultPageLimit(){
+    return matchMedia('(max-width:600px)').matches?12:20;
+  }
+
+  function currentRange(){
+    return $('.chip[data-range][aria-pressed=true]')?.dataset.range||'today';
+  }
+
+  function updateRangeActions(range){
+    $$('.ux-action[data-range-target]').forEach(button=>{
+      const active=button.dataset.rangeTarget===range;
+      button.dataset.active=String(active);
+      if(active) button.dataset.primary='true';
+      else delete button.dataset.primary;
+    });
+  }
+
+  function selectRange(range,scroll=true){
+    const chip=$(`.chip[data-range="${range}"]`);
+    if(!chip) return;
+    chip.click();
+    updateRangeActions(range);
+    if(scroll) scrollToEl($('.statusbar'));
+  }
+
+  function hero(){
+    const root=$('.hero');
+    if(!root) return;
+    const eye=$('.eyebrow',root);
+    const title=$('h1',root);
+    const lede=$('.lede',root);
+    const actions=$('.hero-actions',root);
+    if(eye) eye.textContent='VRCHAT EVENT GUIDE · JST';
+    if(title) title.textContent='今夜のVRChat';
+    if(lede) lede.textContent='開催中・今夜のイベントを、時刻と参加方法から選べます。公式情報へ最短で移動できます。';
+    if(actions&&!$('.ux-data-menu',root)){
+      const details=make('details','ux-data-menu');
+      const summary=make('summary','','データ');
+      actions.replaceWith(details);
+      details.append(summary,actions);
+    }
+  }
+
+  function command(){
+    if($('.ux-command')||!$('.hero')) return;
+    const bar=make('section','ux-command');
+    bar.setAttribute('aria-label','クイック操作');
+    bar.innerHTML=`
+      <div class="ux-next" aria-live="polite">
+        <span class="ux-live">UPCOMING</span>
+        <span class="ux-next-copy">
+          <strong id="ux-next-title">イベントを読み込み中</strong>
+          <span id="ux-next-meta">開催情報を確認しています</span>
+        </span>
+      </div>
+      <div class="ux-actions">
+        <button class="ux-action" data-ux="today" data-range-target="today">今日</button>
+        <button class="ux-action" data-ux="week" data-range-target="week">7日</button>
+        <button class="ux-action" data-ux="search">検索</button>
+        <button class="ux-action" data-ux="recommend">おすすめ</button>
+        <button class="ux-density" data-ux="density">詳細表示</button>
+      </div>`;
+    $('.hero').after(bar);
+    bar.addEventListener('click',event=>{
+      const action=event.target.closest('[data-ux]')?.dataset.ux;
+      if(action==='today'||action==='week') selectRange(action);
+      if(action==='recommend') scrollToEl($('#recommendations'));
+      if(action==='search'){
+        scrollToEl($('.controls'));
+        setTimeout(()=>$('#q')?.focus(),180);
+      }
+      if(action==='density') density();
+    });
+  }
+
+  function filters(){
+    const controls=$('.controls');
+    if(!controls||$('.ux-filter-toggle',controls)) return;
+    const button=make('button','ux-filter-toggle','カテゴリ・情報源・期間を絞り込む');
+    button.type='button';
+    button.setAttribute('aria-expanded','false');
+    button.onclick=()=>{
+      const open=controls.classList.toggle('ux-filters-open');
+      button.setAttribute('aria-expanded',String(open));
+      button.textContent=open?'絞り込みを閉じる':'カテゴリ・情報源・期間を絞り込む';
+    };
+    controls.append(button);
+  }
+
+  function reset(){
+    const row=$('.filter-row');
+    if(!row||$('.ux-reset',row)) return;
+    const button=make('button','ux-reset','条件をリセット');
+    button.type='button';
+    button.onclick=()=>{
+      for(const [id,value] of [['q',''],['category','all'],['source','all']]){
+        const element=$(`#${id}`);
+        if(!element) continue;
+        element.value=value;
+        element.dispatchEvent(new Event(id==='q'?'input':'change',{bubbles:true}));
+      }
+      const deadlines=$('#include-deadlines');
+      if(deadlines){
+        deadlines.checked=false;
+        deadlines.dispatchEvent(new Event('change',{bubbles:true}));
+      }
+      selectRange('today',false);
+    };
+    row.append(button);
+  }
+
+  function metrics(){
+    for(const [id,range] of [['metric-today','today'],['metric-week','week'],['metric-total','all']]){
+      const metric=$(`#${id}`)?.closest('.metric');
+      if(!metric||metric.dataset.uxRange) continue;
+      metric.dataset.uxRange=range;
+      metric.tabIndex=0;
+      metric.setAttribute('role','button');
+      metric.setAttribute('aria-label',`${metric.textContent.trim()}を表示`);
+      const run=()=>selectRange(range);
+      metric.onclick=run;
+      metric.onkeydown=event=>{
+        if(event.key==='Enter'||event.key===' '){
+          event.preventDefault();
+          run();
+        }
+      };
+    }
+  }
+
+  function density(force){
+    const detailed=typeof force==='boolean'?force:!document.body.classList.contains('ux-detailed');
+    document.body.classList.toggle('ux-detailed',detailed);
+    try{localStorage.setItem(DETAIL_KEY,detailed?'1':'0')}catch{}
+    $$('.ux-density').forEach(button=>{
+      button.textContent=detailed?'標準表示':'詳細表示';
+      button.setAttribute('aria-pressed',String(detailed));
+    });
+  }
+
+  function topButton(){
+    if($('.ux-back-top')) return;
+    const button=make('button','ux-back-top','↑');
+    button.type='button';
+    button.setAttribute('aria-label','ページ先頭へ戻る');
+    button.dataset.visible='false';
+    button.onclick=()=>window.scrollTo({top:0,behavior:'smooth'});
+    document.body.append(button);
+    addEventListener('scroll',()=>button.dataset.visible=String(scrollY>720),{passive:true});
+  }
+
+  function applyPagination(){
+    const agenda=$('#agenda');
+    if(!agenda) return;
+    const events=$$('.event',agenda);
+    events.forEach((event,index)=>event.hidden=index>=pageLimit);
+    $$('.day',agenda).forEach(day=>{
+      day.hidden=!$$('.event',day).some(event=>!event.hidden);
+    });
+
+    let button=$('.ux-load-more');
+    const remaining=Math.max(0,events.length-pageLimit);
+    if(!remaining){
+      button?.remove();
+      return;
+    }
+    if(!button){
+      button=make('button','ux-load-more');
+      button.type='button';
+      agenda.after(button);
+      button.onclick=()=>{
+        pageLimit+=defaultPageLimit();
+        applyPagination();
+      };
+    }
+    button.textContent=`さらに表示（残り${remaining}件）`;
+  }
+
+  function enhance(){
+    const first=$('.event:not([hidden])');
+    const title=$('#ux-next-title');
+    const meta=$('#ux-next-meta');
+
+    $$('.event').forEach(card=>{
+      if(card.dataset.uxEnhanced===VERSION) return;
+      card.dataset.uxEnhanced=VERSION;
+      const name=$('h2',card)?.textContent.trim();
+      if(name) card.setAttribute('aria-label',name);
+      $$('.event-link',card).forEach((link,index)=>{
+        if(index===0) link.setAttribute('aria-label',`${name||'イベント'}の公式情報を開く`);
+      });
+    });
+
+    applyPagination();
+    const visible=$('.event:not([hidden])');
+    if(!title||!meta) return;
+    if(!visible){
+      title.textContent='条件に合うイベントはありません';
+      meta.textContent='期間または絞り込み条件を変更してください';
+      return;
+    }
+    title.textContent=$('h2',visible)?.textContent.trim()||'次のイベント';
+    meta.textContent=[
+      visible.closest('.day')?.querySelector('.day-label strong')?.textContent.trim(),
+      $('.time',visible)?.textContent.replace(/\s+/g,' ').trim(),
+    ].filter(Boolean).join(' · ');
+  }
+
+  function observe(){
+    const agenda=$('#agenda');
+    if(!agenda) return;
+    const observer=new MutationObserver(()=>{
+      pageLimit=defaultPageLimit();
+      queueMicrotask(enhance);
+    });
+    observer.observe(agenda,{childList:true,subtree:true});
+    enhance();
+  }
+
+  function keyboard(){
+    addEventListener('keydown',event=>{
+      const editing=event.target instanceof HTMLInputElement||event.target instanceof HTMLSelectElement||event.target instanceof HTMLTextAreaElement;
+      if(event.key==='/'&&!editing){
+        event.preventDefault();
+        scrollToEl($('.controls'));
+        $('#q')?.focus();
+      }
+      if(editing||event.ctrlKey||event.metaKey||event.altKey) return;
+      if(event.key.toLowerCase()==='t') selectRange('today');
+      if(event.key.toLowerCase()==='w') selectRange('week');
+      if(event.key.toLowerCase()==='r') scrollToEl($('#recommendations'));
+    });
+  }
+
+  function start(){
+    document.documentElement.dataset.qualityView=VERSION;
+    $('.ux-mobile-nav')?.remove();
+    if(!$('.skip-link')){
+      const link=make('a','skip-link','イベント一覧へ移動');
+      link.href='#agenda';
+      document.body.prepend(link);
+    }
+    hero();
+    command();
+    filters();
+    reset();
+    metrics();
+    let detailed=false;
+    try{detailed=localStorage.getItem(DETAIL_KEY)==='1'}catch{}
+    density(detailed);
+    topButton();
+    observe();
+    keyboard();
+    $$('.chip[data-range]').forEach(chip=>chip.addEventListener('click',()=>updateRangeActions(chip.dataset.range)));
+    setTimeout(()=>selectRange('today',false),0);
+  }
+
+  document.readyState==='loading'
+    ?document.addEventListener('DOMContentLoaded',start,{once:true})
+    :start();
+})();

--- a/tests/test_pages_quality_view.py
+++ b/tests/test_pages_quality_view.py
@@ -10,7 +10,7 @@ def test_root_function_injects_only_first_party_assets() -> None:
     assert "context.next()" in source
     assert "HTMLRewriter" in source
     assert "x-quality-view" in source
-    assert "2026-08-03-quality-view-v4" in source
+    assert "2026-08-04-quality-view-v5" in source
     assert 'href="/uiux-v4.css"' in source
     assert 'src="/uiux-v4.js"' in source
     assert "https://" not in source
@@ -21,13 +21,18 @@ def test_function_invocation_is_limited_to_root() -> None:
     assert routes == {"version": 1, "include": ["/"], "exclude": []}
 
 
-def test_quality_view_has_accessibility_and_mobile_contracts() -> None:
+def test_quality_view_has_accessibility_mobile_and_density_contracts() -> None:
     css = (ROOT / "public" / "uiux-v4.css").read_text(encoding="utf-8")
     script = (ROOT / "public" / "uiux-v4.js").read_text(encoding="utf-8")
     assert ":focus-visible" in css
     assert "prefers-reduced-motion" in css
-    assert ".ux-mobile-nav" in css
+    assert ".ux-mobile-nav{display:none!important}" in css
+    assert ".ux-filter-toggle" in css
+    assert ".ux-load-more" in css
     assert "MutationObserver" in script
     assert "localStorage" in script
     assert "イベント一覧へ移動" in script
+    assert "selectRange('today',false)" in script
+    assert "applyPagination" in script
+    assert "ux-filters-open" in script
     assert "fetch(" not in script


### PR DESCRIPTION
## Visual findings from the live Pages capture

- desktop first real event started at y=1,369px, below a 1,200px viewport
- mobile first real event started at y=2,840px
- mobile recommendations occupied 1,757px before the event list
- the fixed mobile navigation covered the filter controls
- the default 7-day view rendered 73 cards and produced a 35,231px mobile document

## Changes

- default to today rather than seven days
- compact the hero, upcoming strip, metrics, and controls
- visually order the real event agenda before recommendations
- replace the fixed bottom navigation with compact command actions
- collapse advanced mobile filters behind an explicit control
- render recommendations as a horizontal rail
- paginate long result sets with a load-more control
- advance the production marker to `2026-08-04-quality-view-v5`
- extend contract tests for the new visual hierarchy

The ingestion, event classification, official-link selection, and local recommendation scoring remain unchanged.