### PR TITLE
Clean visual hierarchy implementation branches

### DIFF
--- a/.github/workflows/cleanup-visual-hierarchy-v5.yml
+++ b/.github/workflows/cleanup-visual-hierarchy-v5.yml
@@ -1,0 +1,33 @@
+name: Clean visual hierarchy v5 branches
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/cleanup-visual-hierarchy-v5.yml
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Delete merged branches and remove workflow
+        run: |
+          set -euo pipefail
+          for branch in agent/visual-hierarchy-v5 agent/cleanup-visual-hierarchy-v5; do
+            if git ls-remote --exit-code --heads origin "refs/heads/$branch" >/dev/null 2>&1; then
+              git push origin --delete "$branch"
+            fi
+          done
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          rm .github/workflows/cleanup-visual-hierarchy-v5.yml
+          git add .github/workflows/cleanup-visual-hierarchy-v5.yml
+          git commit -m 'chore: remove visual hierarchy cleanup [skip ci]'
+          git pull --rebase origin main
+          git push origin HEAD:main


### PR DESCRIPTION
Delete the merged v5 implementation branch and this one-time cleanup branch, then remove the cleanup workflow from main. The production implementation, tests, and visual evidence remain unchanged.