### PR TITLE
Clean infinite scroll implementation branches

### DIFF
--- a/.github/workflows/cleanup-infinite-scroll-branches.yml
+++ b/.github/workflows/cleanup-infinite-scroll-branches.yml
@@ -1,0 +1,33 @@
+name: Clean infinite scroll branches
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/cleanup-infinite-scroll-branches.yml
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Delete merged branches and remove workflow
+        run: |
+          set -euo pipefail
+          for branch in agent/infinite-scroll-semantic-cast agent/cleanup-infinite-scroll-canonical; do
+            if git ls-remote --exit-code --heads origin "refs/heads/$branch" >/dev/null 2>&1; then
+              git push origin --delete "$branch"
+            fi
+          done
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          rm .github/workflows/cleanup-infinite-scroll-branches.yml
+          git add .github/workflows/cleanup-infinite-scroll-branches.yml
+          git commit -m 'chore: remove infinite scroll cleanup [skip ci]'
+          git pull --rebase origin main
+          git push origin HEAD:main


### PR DESCRIPTION
Delete the merged infinite-scroll implementation branch and this temporary cleanup branch, then remove the one-time cleanup workflow. The merged implementation and tests remain unchanged on main.