### PR TITLE
Build evidence-gated Yahoo query expert model

### DIFF
--- a/.github/workflows/yahoo-expert-model.yml
+++ b/.github/workflows/yahoo-expert-model.yml
@@ -1,0 +1,77 @@
+name: Yahoo query expert model
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - scripts/build_yahoo_expert_model.py
+      - tests/test_yahoo_expert_model.py
+      - public/yahoo-candidate-history.json
+      - .github/workflows/yahoo-expert-model.yml
+  push:
+    branches: [main]
+    paths:
+      - scripts/build_yahoo_expert_model.py
+      - tests/test_yahoo_expert_model.py
+      - public/yahoo-candidate-history.json
+      - .github/workflows/yahoo-expert-model.yml
+
+permissions:
+  contents: write
+
+concurrency:
+  group: yahoo-expert-model-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Install dependencies
+        run: pip install -e '.[dev]'
+      - name: Regression tests
+        run: pytest -q tests/test_yahoo_expert_model.py tests/test_yahoo_corpus.py tests/test_yahoo_archive_policy.py
+      - name: Build evidence-gated model
+        run: python scripts/build_yahoo_expert_model.py
+      - name: Validate model artifact
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          model = json.loads(Path('public/yahoo-query-expert-model.json').read_text(encoding='utf-8'))
+          assert model['schema_version'] == '1.0'
+          assert model['model_type'] == 'evidence_gated_query_experts'
+          assert model['fail_closed'] is True
+          assert model['status'] in {'ready', 'insufficient_evidence'}
+          assert model['training_rows'] > 0
+          assert model['accepted_universe_count'] > 0
+          assert all(item['support'] == item['accepted'] + item['rejected'] for item in model['experts'])
+          if model['status'] == 'ready':
+              assert model['recommended_query_keys']
+              assert model['ensemble_positive_coverage'] >= model['thresholds']['minimum_ensemble_coverage']
+          else:
+              assert model['recommended_query_keys'] == []
+          PY
+      - name: Commit model evidence
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add public/yahoo-query-expert-model.json
+          if git diff --cached --quiet; then
+            echo 'No expert-model changes'
+          else
+            git commit -m 'chore: refresh Yahoo expert model [skip ci]'
+            git pull --rebase origin main
+            git push origin HEAD:main
+          fi

--- a/scripts/build_yahoo_expert_model.py
+++ b/scripts/build_yahoo_expert_model.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import Counter, defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_HISTORY = Path("public/yahoo-candidate-history.json")
+DEFAULT_OUTPUT = Path("public/yahoo-query-expert-model.json")
+Z_95 = 1.959963984540054
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def wilson_lower(successes: int, total: int, z: float = Z_95) -> float:
+    if total <= 0:
+        return 0.0
+    p = successes / total
+    denominator = 1 + z * z / total
+    centre = p + z * z / (2 * total)
+    margin = z * math.sqrt((p * (1 - p) + z * z / (4 * total)) / total)
+    return max(0.0, (centre - margin) / denominator)
+
+
+def candidate_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        rows = payload
+    elif isinstance(payload, dict):
+        rows = payload.get("candidates", [])
+    else:
+        rows = []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def is_accepted(row: dict[str, Any]) -> bool:
+    return str(row.get("last_decision") or row.get("decision") or "").casefold() == "accepted"
+
+
+def query_keys(row: dict[str, Any]) -> list[str]:
+    values = row.get("query_keys") or []
+    return sorted({str(value).strip() for value in values if str(value).strip()})
+
+
+def build_model(
+    rows: list[dict[str, Any]],
+    *,
+    minimum_support: int = 20,
+    minimum_accepted: int = 2,
+    minimum_wilson_precision: float = 0.05,
+    minimum_ensemble_coverage: float = 0.90,
+) -> dict[str, Any]:
+    observations: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    accepted_ids: set[str] = set()
+    for row in rows:
+        status_id = str(row.get("status_id") or "")
+        if is_accepted(row) and status_id:
+            accepted_ids.add(status_id)
+        for key in query_keys(row):
+            observations[key].append(row)
+
+    experts: list[dict[str, Any]] = []
+    expert_positive_ids: dict[str, set[str]] = {}
+    for key, seen in observations.items():
+        positives = [row for row in seen if is_accepted(row)]
+        positive_ids = {str(row.get("status_id")) for row in positives if row.get("status_id")}
+        support = len(seen)
+        accepted = len(positives)
+        precision = accepted / support if support else 0.0
+        lower = wilson_lower(accepted, support)
+        reasons = Counter(str(row.get("last_reason") or row.get("reason") or "accepted") for row in seen)
+        eligible = support >= minimum_support and accepted >= minimum_accepted and lower >= minimum_wilson_precision
+        if eligible:
+            tier = "precision" if lower >= 0.15 else "balanced" if lower >= 0.08 else "recall"
+        else:
+            tier = "exploration"
+        experts.append(
+            {
+                "query_key": key,
+                "support": support,
+                "accepted": accepted,
+                "rejected": support - accepted,
+                "precision": round(precision, 6),
+                "wilson_precision_lower_95": round(lower, 6),
+                "positive_coverage": round(len(positive_ids) / len(accepted_ids), 6) if accepted_ids else 0.0,
+                "tier": tier,
+                "eligible": eligible,
+                "top_rejection_reasons": dict(reasons.most_common(5)),
+            }
+        )
+        expert_positive_ids[key] = positive_ids
+
+    experts.sort(
+        key=lambda row: (
+            not row["eligible"],
+            -float(row["wilson_precision_lower_95"]),
+            -int(row["accepted"]),
+            str(row["query_key"]),
+        )
+    )
+    promoted = [row for row in experts if row["eligible"]]
+    covered = set().union(*(expert_positive_ids[row["query_key"]] for row in promoted)) if promoted else set()
+    ensemble_coverage = len(covered) / len(accepted_ids) if accepted_ids else 0.0
+
+    ablations: list[dict[str, Any]] = []
+    for expert in promoted:
+        remaining = [row for row in promoted if row["query_key"] != expert["query_key"]]
+        remaining_ids = set().union(*(expert_positive_ids[row["query_key"]] for row in remaining)) if remaining else set()
+        coverage = len(remaining_ids) / len(accepted_ids) if accepted_ids else 0.0
+        ablations.append(
+            {
+                "removed_query_key": expert["query_key"],
+                "coverage_without_expert": round(coverage, 6),
+                "marginal_positive_coverage": round(ensemble_coverage - coverage, 6),
+                "unique_accepted_count": len(covered - remaining_ids),
+            }
+        )
+    ablations.sort(key=lambda row: (-row["marginal_positive_coverage"], row["removed_query_key"]))
+
+    status = "ready" if promoted and ensemble_coverage >= minimum_ensemble_coverage else "insufficient_evidence"
+    return {
+        "schema_version": "1.0",
+        "model_type": "evidence_gated_query_experts",
+        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "status": status,
+        "fail_closed": True,
+        "thresholds": {
+            "minimum_support": minimum_support,
+            "minimum_accepted": minimum_accepted,
+            "minimum_wilson_precision": minimum_wilson_precision,
+            "minimum_ensemble_coverage": minimum_ensemble_coverage,
+        },
+        "training_rows": len(rows),
+        "accepted_universe_count": len(accepted_ids),
+        "promoted_expert_count": len(promoted),
+        "ensemble_positive_coverage": round(ensemble_coverage, 6),
+        "recommended_query_keys": [row["query_key"] for row in promoted] if status == "ready" else [],
+        "experts": experts,
+        "leave_one_expert_out_ablation": ablations,
+        "promotion_policy": "No production query plan change unless status is ready and regression tests verify all hard validity gates remain unchanged.",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build an evidence-gated Yahoo query expert ensemble")
+    parser.add_argument("--history", type=Path, default=DEFAULT_HISTORY)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--minimum-support", type=int, default=20)
+    parser.add_argument("--minimum-accepted", type=int, default=2)
+    parser.add_argument("--minimum-wilson-precision", type=float, default=0.05)
+    parser.add_argument("--minimum-ensemble-coverage", type=float, default=0.90)
+    args = parser.parse_args()
+    payload = build_model(
+        candidate_rows(read_json(args.history)),
+        minimum_support=args.minimum_support,
+        minimum_accepted=args.minimum_accepted,
+        minimum_wilson_precision=args.minimum_wilson_precision,
+        minimum_ensemble_coverage=args.minimum_ensemble_coverage,
+    )
+    write_json(args.output, payload)
+    print(json.dumps({key: payload[key] for key in ("status", "training_rows", "accepted_universe_count", "promoted_expert_count", "ensemble_positive_coverage")}, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_yahoo_expert_model.py
+++ b/tests/test_yahoo_expert_model.py
@@ -1,0 +1,64 @@
+from scripts.build_yahoo_expert_model import build_model, wilson_lower
+
+
+def row(status_id: str, decision: str, keys: list[str], reason: str | None = None) -> dict[str, object]:
+    return {
+        "status_id": status_id,
+        "last_decision": decision,
+        "last_reason": reason,
+        "query_keys": keys,
+    }
+
+
+def test_wilson_lower_is_conservative() -> None:
+    assert wilson_lower(0, 40) == 0.0
+    assert 0.19 < wilson_lower(14, 40) < 0.35
+    assert wilson_lower(14, 40) < 14 / 40
+
+
+def test_model_promotes_precision_and_recall_experts_with_ablation() -> None:
+    rows = []
+    for index in range(30):
+        decision = "accepted" if index < 12 else "rejected"
+        rows.append(row(f"a-{index}", decision, ["expert-a"], "missing_datetime"))
+    for index in range(30):
+        decision = "accepted" if index < 8 else "rejected"
+        keys = ["expert-b"]
+        if index < 4:
+            keys.append("expert-a")
+        rows.append(row(f"b-{index}", decision, keys, "missing_event_marker"))
+
+    model = build_model(
+        rows,
+        minimum_support=20,
+        minimum_accepted=2,
+        minimum_wilson_precision=0.05,
+        minimum_ensemble_coverage=0.90,
+    )
+
+    assert model["status"] == "ready"
+    assert model["fail_closed"] is True
+    assert set(model["recommended_query_keys"]) == {"expert-a", "expert-b"}
+    assert model["ensemble_positive_coverage"] == 1.0
+    assert len(model["leave_one_expert_out_ablation"]) == 2
+    assert any(item["unique_accepted_count"] > 0 for item in model["leave_one_expert_out_ablation"])
+
+
+def test_model_fails_closed_when_evidence_or_coverage_is_insufficient() -> None:
+    rows = [row(f"x-{index}", "accepted" if index == 0 else "rejected", ["weak"]) for index in range(10)]
+    model = build_model(rows)
+    assert model["status"] == "insufficient_evidence"
+    assert model["recommended_query_keys"] == []
+    assert model["promoted_expert_count"] == 0
+
+
+def test_negative_reasons_are_metrics_not_hard_exclusions() -> None:
+    rows = [
+        row(f"p-{index}", "accepted" if index < 10 else "rejected", ["mixed"], "product_only")
+        for index in range(30)
+    ]
+    model = build_model(rows, minimum_ensemble_coverage=1.0)
+    expert = next(item for item in model["experts"] if item["query_key"] == "mixed")
+    assert expert["eligible"] is True
+    assert expert["top_rejection_reasons"]["product_only"] == 30
+    assert "product_only" not in model.get("recommended_query_keys", [])


### PR DESCRIPTION
## Purpose

Replace intuition-driven Yahoo seed-query edits with a quantitatively evaluated query-expert ensemble.

## Model

- trains only from the retained Yahoo candidate ledger and query provenance
- computes support, accepted/rejected counts, empirical precision, 95% Wilson precision lower bound, positive coverage, and rejection-reason distribution per query expert
- promotes an expert only when minimum support, accepted count, and conservative precision thresholds are all met
- assigns promoted experts to precision, balanced, or recall tiers
- runs leave-one-expert-out ablation to measure marginal accepted-event coverage and unique positive contribution
- returns `recommended_query_keys: []` unless the ensemble passes the configured positive-coverage gate

## Fail-closed boundary

This PR does not directly replace the production query plan. It produces `public/yahoo-query-expert-model.json` as evidence. Production promotion must be a separate reviewed change after the artifact reports `status: ready` and the hard identity, VRChat relevance, explicit datetime, event/recruitment intent, engagement, commerce, giveaway, duplicate, malformed, and ambiguity regression suites remain green.

## Validation

- focused unit tests cover Wilson conservatism, expert promotion, leave-one-out ablation, insufficient-evidence fail-closed behavior, and negative-reason auditing
- CI builds and validates the model against the current retained candidate history
- main-branch runs commit only the generated evidence artifact
