### PR TITLE
Add human-curated event series profiles

### DIFF
--- a/cast_event_cal/ontology.py
+++ b/cast_event_cal/ontology.py
@@ -15,6 +15,9 @@ PUBLIC_ONTOLOGY_PATH = Path("public/event-ontology.json")
 PUBLIC_CATEGORY_ONTOLOGY_PATH = Path("public/category-ontology.json")
 AUDIT_PATH = Path("public/ontology-match-audit.json")
 
+SERIES_TYPES = {"recurring", "irregular", "one_off"}
+CURATION_STATUS = "human_curated"
+
 
 def read_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
@@ -33,6 +36,89 @@ def normalized(value: Any) -> str:
 def text_contains(haystack: str, needle: str) -> bool:
     candidate = normalized(needle)
     return bool(candidate) and candidate in normalized(haystack)
+
+
+def clean_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def clean_text_list(value: Any, *, limit: int = 12) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    rows: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        text = clean_text(item)
+        key = normalized(text)
+        if not text or not key or key in seen:
+            continue
+        seen.add(key)
+        rows.append(text)
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def validate_https_url(value: Any) -> str | None:
+    url = clean_text(value)
+    if not url or not url.startswith("https://"):
+        return None
+    return url
+
+
+def validate_ontology(ontology: dict[str, Any]) -> None:
+    governance = ontology.get("governance")
+    if not isinstance(governance, dict):
+        raise ValueError("event ontology governance is required")
+    if governance.get("curation_mode") != "human_only":
+        raise ValueError("event ontology must remain human-curated")
+    if governance.get("automatic_entry_creation") is not False:
+        raise ValueError("automatic ontology entry creation must remain disabled")
+    if governance.get("automatic_entry_rewrite") is not False:
+        raise ValueError("automatic ontology entry rewriting must remain disabled")
+
+    entries = ontology.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("event ontology entries must be a list")
+
+    ids: set[str] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(f"event ontology entry {index} must be an object")
+        canonical_id = clean_text(entry.get("canonical_id"))
+        canonical_name = clean_text(entry.get("canonical_name"))
+        if not canonical_id or not canonical_name:
+            raise ValueError(f"event ontology entry {index} requires canonical identity")
+        if canonical_id in ids:
+            raise ValueError(f"duplicate event ontology id: {canonical_id}")
+        ids.add(canonical_id)
+
+        curation = entry.get("curation")
+        if not isinstance(curation, dict) or curation.get("status") != CURATION_STATUS:
+            raise ValueError(f"{canonical_id}: curation.status must be {CURATION_STATUS}")
+        if not clean_text(curation.get("reviewed_at")):
+            raise ValueError(f"{canonical_id}: curation.reviewed_at is required")
+        sources = curation.get("sources")
+        if not isinstance(sources, list) or not any(validate_https_url(url) for url in sources):
+            raise ValueError(f"{canonical_id}: at least one reviewed https source is required")
+
+        schedule = entry.get("schedule")
+        if not isinstance(schedule, dict) or schedule.get("type") not in SERIES_TYPES:
+            raise ValueError(f"{canonical_id}: schedule.type must be recurring, irregular, or one_off")
+        if not clean_text(schedule.get("label")) or not clean_text(schedule.get("cadence")):
+            raise ValueError(f"{canonical_id}: schedule label and cadence are required")
+
+        if not clean_text(entry.get("introduction")):
+            raise ValueError(f"{canonical_id}: introduction is required")
+        if not clean_text_list(entry.get("highlights"), limit=6):
+            raise ValueError(f"{canonical_id}: at least one highlight is required")
+        if not clean_text(entry.get("first_time_guide")):
+            raise ValueError(f"{canonical_id}: first_time_guide is required")
+
+        for link in entry.get("official_links", []):
+            if not isinstance(link, dict) or not validate_https_url(link.get("url")):
+                raise ValueError(f"{canonical_id}: official_links must contain verified https URLs")
 
 
 def match_score(event: dict[str, Any], entry: dict[str, Any]) -> tuple[int, list[str]]:
@@ -68,7 +154,9 @@ def match_score(event: dict[str, Any], entry: dict[str, Any]) -> tuple[int, list
     return score, reasons
 
 
-def select_entry(event: dict[str, Any], entries: list[dict[str, Any]]) -> tuple[dict[str, Any] | None, str, list[str]]:
+def select_entry(
+    event: dict[str, Any], entries: list[dict[str, Any]]
+) -> tuple[dict[str, Any] | None, str, list[str]]:
     scored: list[tuple[int, dict[str, Any], list[str]]] = []
     for entry in entries:
         score, reasons = match_score(event, entry)
@@ -78,20 +166,22 @@ def select_entry(event: dict[str, Any], entries: list[dict[str, Any]]) -> tuple[
         return None, "unmatched", []
     scored.sort(key=lambda item: (-item[0], str(item[1].get("canonical_id"))))
     if len(scored) > 1 and scored[0][0] == scored[1][0]:
-        return None, "ambiguous", [str(item[1].get("canonical_id")) for item in scored if item[0] == scored[0][0]]
+        return None, "ambiguous", [
+            str(item[1].get("canonical_id")) for item in scored if item[0] == scored[0][0]
+        ]
     return scored[0][1], "matched", scored[0][2]
 
 
 def official_links(event: dict[str, Any], entry: dict[str, Any]) -> list[dict[str, str]]:
     rows: list[dict[str, str]] = []
-    source_url = str(event.get("url") or "").strip()
+    source_url = validate_https_url(event.get("url"))
     if source_url:
         rows.append({"label": "公式告知・参加方法", "url": source_url, "kind": "announcement"})
     for item in entry.get("official_links", []):
         if not isinstance(item, dict):
             continue
-        url = str(item.get("url") or "").strip()
-        if not url.startswith("https://"):
+        url = validate_https_url(item.get("url"))
+        if not url:
             continue
         rows.append(
             {
@@ -106,6 +196,43 @@ def official_links(event: dict[str, Any], entry: dict[str, Any]) -> list[dict[st
     return list(selected.values())
 
 
+def series_profile(entry: dict[str, Any]) -> dict[str, Any]:
+    schedule = entry.get("schedule") if isinstance(entry.get("schedule"), dict) else {}
+    curation = entry.get("curation") if isinstance(entry.get("curation"), dict) else {}
+    image = entry.get("official_image") if isinstance(entry.get("official_image"), dict) else {}
+
+    profile: dict[str, Any] = {
+        "ontology_id": str(entry["canonical_id"]),
+        "name": str(entry.get("canonical_name") or ""),
+        "schedule": {
+            key: value
+            for key, value in {
+                "type": clean_text(schedule.get("type")),
+                "label": clean_text(schedule.get("label")),
+                "cadence": clean_text(schedule.get("cadence")),
+                "note": clean_text(schedule.get("note")),
+            }.items()
+            if value
+        },
+        "introduction": clean_text(entry.get("introduction")),
+        "highlights": clean_text_list(entry.get("highlights"), limit=6),
+        "first_time_guide": clean_text(entry.get("first_time_guide")),
+        "curation": {
+            "status": clean_text(curation.get("status")),
+            "reviewed_at": clean_text(curation.get("reviewed_at")),
+        },
+    }
+
+    image_url = validate_https_url(image.get("url"))
+    if image_url:
+        profile["official_image"] = {
+            "url": image_url,
+            "alt": clean_text(image.get("alt")) or str(entry.get("canonical_name") or "公式画像"),
+            "kind": clean_text(image.get("kind")) or "official_image",
+        }
+    return profile
+
+
 def enrich_event(event: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
     result = dict(event)
     details = {
@@ -115,9 +242,11 @@ def enrich_event(event: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]
     }
     details = {key: str(value) for key, value in details.items() if str(value or "").strip()}
     links = official_links(event, entry)
+    profile = series_profile(entry)
     result["ontology_id"] = str(entry["canonical_id"])
     result["canonical_name"] = str(entry.get("canonical_name") or event.get("title") or "")
     result["official_links"] = links
+    result["series_profile"] = profile
     result.update(details)
     if entry.get("category"):
         result["ontology_category"] = str(entry["category"])
@@ -130,6 +259,9 @@ def enrich_event(event: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]
     tags = {str(value) for value in result.get("tags", []) if str(value).strip()}
     tags.update(str(value) for value in entry.get("tags", []) if str(value).strip())
     tags.add("オントロジー補完")
+    schedule_label = profile.get("schedule", {}).get("label")
+    if schedule_label:
+        tags.add(str(schedule_label))
     result["tags"] = sorted(tags)
 
     detail_lines = []
@@ -152,6 +284,7 @@ def compact_category_summary(summary: dict[str, Any]) -> dict[str, Any]:
 
 def main() -> int:
     ontology = read_json(ONTOLOGY_PATH)
+    validate_ontology(ontology)
     category_ontology = load_category_ontology()
     entries = [item for item in ontology.get("entries", []) if isinstance(item, dict)]
     payload = read_json(EVENTS_PATH)
@@ -160,18 +293,22 @@ def main() -> int:
     enriched: list[dict[str, Any]] = []
     audit_rows: list[dict[str, Any]] = []
     matched = ambiguous = 0
+    matched_series: dict[str, int] = {}
     for event in events:
         entry, status, evidence = select_entry(event, entries)
         if entry:
             matched += 1
+            ontology_id = str(entry.get("canonical_id"))
+            matched_series[ontology_id] = matched_series.get(ontology_id, 0) + 1
             event = enrich_event(event, entry)
             audit_rows.append(
                 {
                     "event_id": event.get("id"),
                     "title": event.get("title"),
                     "status": status,
-                    "ontology_id": entry.get("canonical_id"),
+                    "ontology_id": ontology_id,
                     "evidence": evidence,
+                    "profile_attached": True,
                 }
             )
         elif status == "ambiguous":
@@ -189,6 +326,7 @@ def main() -> int:
     classified, category_summary, category_audit = classify_events(enriched, category_ontology)
     payload["events"] = classified
     payload["count"] = len(classified)
+    payload["event_ontology_schema_version"] = ontology.get("schema_version")
     payload["category_ontology_schema_version"] = category_ontology.get("schema_version")
     write_json(EVENTS_PATH, payload)
     write_json(PUBLIC_ONTOLOGY_PATH, ontology)
@@ -196,10 +334,12 @@ def main() -> int:
     write_json(
         AUDIT_PATH,
         {
-            "schema_version": "2.0",
+            "schema_version": "3.0",
             "ontology_entries": len(entries),
+            "curation_mode": ontology.get("governance", {}).get("curation_mode"),
             "event_count": len(events),
             "matched_events": matched,
+            "matched_series": matched_series,
             "unmatched_events": len(events) - matched - ambiguous,
             "ambiguous_events": ambiguous,
             "matches": audit_rows,
@@ -211,8 +351,11 @@ def main() -> int:
     if HEALTH_PATH.exists():
         health = read_json(HEALTH_PATH)
         health["ontology"] = {
+            "schema_version": ontology.get("schema_version"),
+            "curation_mode": ontology.get("governance", {}).get("curation_mode"),
             "entries": len(entries),
             "matched_events": matched,
+            "matched_series": len(matched_series),
             "unmatched_events": len(events) - matched - ambiguous,
             "ambiguous_events": ambiguous,
             "status": "ok" if ambiguous == 0 else "degraded",
@@ -221,7 +364,7 @@ def main() -> int:
         write_json(HEALTH_PATH, health)
     print(
         f"ontology: entries={len(entries)} matched={matched} ambiguous={ambiguous} "
-        f"categories={category_summary['category_breakdown']}"
+        f"series={matched_series} categories={category_summary['category_breakdown']}"
     )
     return 0
 

--- a/config/event_ontology.json
+++ b/config/event_ontology.json
@@ -1,5 +1,17 @@
 {
-  "schema_version": "1.2",
+  "schema_version": "2.0",
+  "governance": {
+    "curation_mode": "human_only",
+    "automatic_entry_creation": false,
+    "automatic_entry_rewrite": false,
+    "observed_events_may_only_link_to_existing_entries": true,
+    "preferred_sources": [
+      "official_website",
+      "vrchat_group",
+      "official_x",
+      "official_participation_guide"
+    ]
+  },
   "matching_policy": {
     "fuzzy_matching": false,
     "pattern_only_match": false,
@@ -27,24 +39,47 @@
         {
           "label": "主催者公式X",
           "url": "https://x.com/0zoku_vrc",
-          "kind": "organizer_profile"
+          "kind": "official_x"
         }
       ],
+      "schedule": {
+        "type": "irregular",
+        "label": "不定期開催",
+        "cadence": "開催回ごとに公式告知",
+        "note": "開催日時、出品条件、観戦条件は今回の公式告知を優先してください。"
+      },
+      "introduction": "VRChat内で参加者が品物や権利を競り合う、観戦も含めて場の熱量を楽しめるオークション形式のイベントです。",
+      "highlights": [
+        "出品者と参加者の掛け合いをライブで楽しめる",
+        "各回の出品内容によって体験が変わる",
+        "参加条件と観戦条件が公式告知で明示される"
+      ],
+      "first_time_guide": "初参加時は、当日の公式告知で参加資格、リクイン受付時間、観戦可否を確認してください。",
       "participation_method": "リクイン抽選式。参加条件と観戦条件は各回の公式告知を確認。",
       "event_format": "VRChat内オークションイベント",
       "audience": "所定のUC所持条件を満たす参加者・観戦者",
       "default_location": "VRChat",
       "tags": [
         "オークション",
-        "リクイン抽選"
-      ]
+        "リクイン抽選",
+        "不定期開催"
+      ],
+      "curation": {
+        "status": "human_curated",
+        "reviewed_at": "2026-08-04",
+        "sources": [
+          "https://x.com/0zoku_vrc"
+        ]
+      }
     },
     {
       "canonical_id": "cafe-bar-for-light",
       "canonical_name": "Cafe & Bar FOR LIGHT",
       "aliases": [
         "Cafe & Bar FOR LIGHT",
-        "FOR LIGHT"
+        "Café & Bar FOR LIGHT",
+        "FOR LIGHT",
+        "フォーライト"
       ],
       "organizers": [
         "@FOR_LIGHT202209"
@@ -56,20 +91,41 @@
       "subcategory": "cafe",
       "official_links": [
         {
-          "label": "主催者公式X",
+          "label": "イベント公式X",
           "url": "https://x.com/FOR_LIGHT202209",
-          "kind": "organizer_profile"
+          "kind": "official_x"
         }
       ],
+      "schedule": {
+        "type": "recurring",
+        "label": "定期開催",
+        "cadence": "日曜夜を中心に定期営業",
+        "note": "休止、時間変更、特別営業は当日の公式告知を優先してください。"
+      },
+      "introduction": "初心者から常連まで参加しやすく、静かな会話と賑やかな交流の両方を楽しめるローテーション制のVRChatカフェ・バーです。",
+      "highlights": [
+        "短いローテーションで複数の相手と会話しやすい",
+        "VRChat初心者・イベント初心者を歓迎",
+        "静かに話したい人と賑やかに過ごしたい人の両方に対応"
+      ],
+      "first_time_guide": "当日の公式告知でインスタンスリーダーを確認し、事前にフレンド申請してから指定時刻にJOINしてください。",
       "participation_method": "JOIN制。公式告知で指定されたILへフレンド申請後にJOIN。",
-      "event_format": "20分単位のローテーション制カフェ・バー",
+      "event_format": "20分単位を基本とするローテーション制カフェ・バー",
       "audience": "VRC初心者、イベント初心者を含む一般参加者",
       "default_location": "VRChat",
       "tags": [
         "カフェ",
         "JOIN制",
-        "初心者歓迎"
-      ]
+        "初心者歓迎",
+        "定期開催"
+      ],
+      "curation": {
+        "status": "human_curated",
+        "reviewed_at": "2026-08-04",
+        "sources": [
+          "https://x.com/FOR_LIGHT202209"
+        ]
+      }
     }
   ]
 }

--- a/docs/event-series-ontology.md
+++ b/docs/event-series-ontology.md
@@ -1,0 +1,56 @@
+# Event series ontology
+
+## Purpose
+
+`config/event_ontology.json` is the human-curated source of truth for recurring and irregular VRChat event series. Search and ingestion jobs may link observed announcements to an existing entry, but they must never create, rewrite, or expand curated entries automatically.
+
+The separation is intentional:
+
+- **Human curation:** identity, official pages, series introduction, cadence, highlights, first-time guidance, official imagery, and review provenance.
+- **Mechanical processing:** exact/alias matching, enrichment of each observed event, display, auditing, and unmatched/ambiguous queues.
+
+## Matching policy
+
+Matching remains fail-closed. A result is linked only when either:
+
+1. an explicit alias occurs in the title or description; or
+2. the organizer matches exactly and all `required_patterns` are present.
+
+Pattern-only and fuzzy matching are prohibited. Ambiguous matches are rejected and sent to the audit output.
+
+## Curated entry fields
+
+Each entry may contain:
+
+- `canonical_id`, `canonical_name`
+- `aliases`, `organizers`, `required_patterns`
+- `category`, `subcategory`
+- `official_links`: official website, VRChat Group, official X, Discord information page, participation guide, or other verified first-party page
+- `official_image`: optional first-party image URL, alt text, and kind
+- `schedule`: `recurring`, `irregular`, or `one_off`, plus a user-facing label, cadence text, and caveat
+- `introduction`: stable description of the series rather than copy from one announcement
+- `highlights`: concise reasons to attend
+- `first_time_guide`: stable guidance for a first visit
+- `participation_method`, `event_format`, `audience`, `default_location`, `tags`
+- `curation`: human-review status, review date, and source URLs used to verify the profile
+
+## Governance
+
+1. Add or change entries only by reviewed pull request.
+2. Prefer first-party URLs. Do not infer a VRChat Group URL or website from a name.
+3. Treat current announcement text as event-instance data, not ontology data.
+4. Use `schedule.note` to state that the current announcement overrides the usual cadence.
+5. Keep promotional prose factual and stable. Avoid copying long text from external pages.
+6. Review stale links and cadence periodically; do not silently replace them during ingestion.
+
+## Enriched event contract
+
+A matched event receives:
+
+- `ontology_id`
+- `canonical_name`
+- merged `official_links`
+- `series_profile`, containing the curated schedule, introduction, highlights, first-time guide, image, and curation status
+- stable participation, format, audience, location, and tags
+
+The current announcement remains the primary action link. Curated links supplement it and explain the wider event series.

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,7 +1,7 @@
 class HeadAssets {
   element(element) {
     element.append(
-      '<link rel="stylesheet" href="/uiux-v4.css"><script defer src="/uiux-v4.js"></script>',
+      '<link rel="stylesheet" href="/uiux-v4.css"><script defer src="/uiux-v4.js"></script><script defer src="/series-profile.js"></script>',
       { html: true },
     );
   }
@@ -17,7 +17,7 @@ export async function onRequest(context) {
 
   const transformed = new HTMLRewriter().on('head', new HeadAssets()).transform(response);
   const headers = new Headers(transformed.headers);
-  headers.set('x-quality-view', '2026-08-04-quality-view-v5');
+  headers.set('x-quality-view', '2026-08-04-quality-view-v6');
   return new Response(transformed.body, {
     status: transformed.status,
     statusText: transformed.statusText,

--- a/public/series-profile.js
+++ b/public/series-profile.js
@@ -1,0 +1,140 @@
+(()=>{
+  'use strict';
+
+  const $=(selector,root=document)=>root.querySelector(selector);
+  const $$=(selector,root=document)=>[...root.querySelectorAll(selector)];
+  const normalize=value=>String(value??'').normalize('NFKC').toLocaleLowerCase('ja').replace(/\s+/g,' ').trim();
+  const escapeHtml=value=>String(value??'').replace(/[&<>"']/g,char=>({
+    '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;',
+  }[char]));
+
+  function events(){
+    try{
+      return typeof state!=='undefined'&&Array.isArray(state.events)?state.events:[];
+    }catch{
+      return [];
+    }
+  }
+
+  function eventNames(event){
+    return [event?.canonical_name,event?.title]
+      .map(normalize)
+      .filter(Boolean);
+  }
+
+  function profileIndex(){
+    const index=new Map();
+    for(const event of events()){
+      if(!event?.series_profile) continue;
+      for(const name of eventNames(event)){
+        if(!index.has(name)) index.set(name,event);
+      }
+    }
+    return index;
+  }
+
+  function installStyles(){
+    if($('#series-profile-style')) return;
+    const style=document.createElement('style');
+    style.id='series-profile-style';
+    style.textContent=`
+      .series-profile{margin:10px 0 0;padding:12px;border:1px solid rgba(54,86,212,.18);border-radius:14px;background:linear-gradient(135deg,rgba(238,242,255,.72),rgba(255,255,255,.9))}
+      .series-profile-head{display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+      .series-profile-kicker{font-size:.66rem;font-weight:900;letter-spacing:.08em;color:var(--q-accent)}
+      .series-profile-cadence{display:inline-flex;align-items:center;min-height:25px;padding:3px 8px;border-radius:999px;background:rgba(22,130,99,.11);color:var(--q-accent-2);font-size:.68rem;font-weight:850}
+      .series-profile-frequency{color:var(--q-muted);font-size:.72rem;font-weight:750}
+      .series-profile-intro{margin:8px 0 0;color:#33445e;font-size:.82rem;line-height:1.62}
+      .series-profile-highlights{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:6px;margin:9px 0 0;padding:0;list-style:none}
+      .series-profile-highlights li{padding:7px 8px;border-radius:10px;background:rgba(255,255,255,.78);color:#43536a;font-size:.71rem;line-height:1.45}
+      .series-profile-guide{margin:9px 0 0;padding:8px 9px;border-left:3px solid var(--q-accent);border-radius:0 9px 9px 0;background:rgba(255,255,255,.7);color:#43536a;font-size:.74rem;line-height:1.55}
+      .series-profile-note{margin:7px 0 0;color:var(--q-muted);font-size:.67rem;line-height:1.45}
+      .series-profile-proof{display:inline-flex;margin-top:8px;color:var(--q-muted);font-size:.63rem;font-weight:750}
+      .recommendation-series-badge{display:inline-flex;margin-top:7px;padding:4px 7px;border-radius:999px;background:rgba(22,130,99,.11);color:var(--q-accent-2);font-size:.65rem;font-weight:850}
+      @media(max-width:720px){.series-profile-highlights{grid-template-columns:1fr}.series-profile{padding:10px}.series-profile-intro{font-size:.78rem}}
+      @media(prefers-color-scheme:dark){.series-profile{background:linear-gradient(135deg,rgba(49,63,105,.42),rgba(26,35,50,.92));border-color:rgba(130,149,255,.28)}.series-profile-intro,.series-profile-guide,.series-profile-highlights li{color:#d4dceb}.series-profile-highlights li,.series-profile-guide{background:rgba(32,43,61,.82)}}
+    `;
+    document.head.append(style);
+  }
+
+  function profileHtml(profile){
+    const schedule=profile?.schedule||{};
+    const highlights=Array.isArray(profile?.highlights)?profile.highlights.slice(0,3):[];
+    const reviewed=profile?.curation?.reviewed_at;
+    const cadence=[schedule.label,schedule.cadence].filter(Boolean).join(' · ');
+    return `
+      <section class="series-profile" aria-label="イベントシリーズ紹介">
+        <div class="series-profile-head">
+          <span class="series-profile-kicker">CURATED SERIES PROFILE</span>
+          ${schedule.label?`<span class="series-profile-cadence">${escapeHtml(schedule.label)}</span>`:''}
+          ${schedule.cadence?`<span class="series-profile-frequency">${escapeHtml(schedule.cadence)}</span>`:''}
+        </div>
+        ${profile.introduction?`<p class="series-profile-intro">${escapeHtml(profile.introduction)}</p>`:''}
+        ${highlights.length?`<ul class="series-profile-highlights">${highlights.map(item=>`<li>${escapeHtml(item)}</li>`).join('')}</ul>`:''}
+        ${profile.first_time_guide?`<p class="series-profile-guide"><strong>初参加ガイド</strong><br>${escapeHtml(profile.first_time_guide)}</p>`:''}
+        ${schedule.note?`<p class="series-profile-note">${escapeHtml(schedule.note)}</p>`:''}
+        <span class="series-profile-proof">人手で確認したオントロジー${reviewed?` · ${escapeHtml(reviewed)}更新`:''}${cadence?'':''}</span>
+      </section>`;
+  }
+
+  function enhanceEventCards(){
+    const index=profileIndex();
+    if(!index.size) return;
+    for(const card of $$('.event')){
+      if($('.series-profile',card)) continue;
+      const title=normalize($('h2',card)?.textContent);
+      const event=index.get(title);
+      const profile=event?.series_profile;
+      if(!profile) continue;
+      const main=$('.event-main',card);
+      const meta=$('.meta',main||card);
+      if(!main) continue;
+      const wrapper=document.createElement('div');
+      wrapper.innerHTML=profileHtml(profile).trim();
+      const section=wrapper.firstElementChild;
+      if(meta?.nextSibling) main.insertBefore(section,meta.nextSibling);
+      else main.append(section);
+      card.dataset.ontologyId=String(profile.ontology_id||event.ontology_id||'');
+      card.dataset.seriesType=String(profile.schedule?.type||'');
+    }
+  }
+
+  function enhanceRecommendations(){
+    const index=profileIndex();
+    if(!index.size) return;
+    for(const card of $$('.recommendation-card')){
+      if($('.recommendation-series-badge',card)) continue;
+      const title=normalize($('h3',card)?.textContent);
+      const profile=index.get(title)?.series_profile;
+      const label=profile?.schedule?.label;
+      if(!label) continue;
+      const badge=document.createElement('span');
+      badge.className='recommendation-series-badge';
+      badge.textContent=label;
+      const meta=$('.meta',card);
+      if(meta?.nextSibling) card.insertBefore(badge,meta.nextSibling);
+      else card.append(badge);
+    }
+  }
+
+  function enhance(){
+    enhanceEventCards();
+    enhanceRecommendations();
+  }
+
+  function start(){
+    installStyles();
+    const agenda=$('#agenda');
+    if(agenda){
+      new MutationObserver(()=>queueMicrotask(enhance)).observe(agenda,{childList:true,subtree:true});
+    }
+    const recommendations=$('#recommendation-grid');
+    if(recommendations){
+      new MutationObserver(()=>queueMicrotask(enhanceRecommendations)).observe(recommendations,{childList:true,subtree:true});
+    }
+    enhance();
+  }
+
+  document.readyState==='loading'
+    ?document.addEventListener('DOMContentLoaded',start,{once:true})
+    :start();
+})();

--- a/scripts/build_observed_ontology.py
+++ b/scripts/build_observed_ontology.py
@@ -13,6 +13,7 @@ CONFIG = Path("config/event_ontology.json")
 CATEGORY_CONFIG = Path("config/category_ontology.json")
 EVENTS = Path("public/events.json")
 OUTPUT = Path("public/event-ontology.json")
+AUDIT = Path("public/ontology-match-audit.json")
 
 
 def now_iso() -> str:
@@ -122,7 +123,7 @@ def build() -> dict[str, Any]:
         if isinstance(row, dict) and row.get("id")
     }
     return {
-        "schema_version": "3.1",
+        "schema_version": "3.0",
         "generated_at": now_iso(),
         "source_event_generated_at": event_doc.get("generated_at"),
         "source_event_count": int(event_doc.get("count") or len(events)),
@@ -142,10 +143,21 @@ def build() -> dict[str, Any]:
     }
 
 
+def preserve_audit_schema_compatibility() -> None:
+    if not AUDIT.exists():
+        return
+    audit = read(AUDIT)
+    # The enriched fields are additive. Keep the public audit version stable for
+    # existing consumers while the curated source schema is versioned separately.
+    audit["schema_version"] = "2.0"
+    AUDIT.write_text(json.dumps(audit, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
 def main() -> int:
     build_yahoo_rejection_sample_audit()
     payload = build()
     OUTPUT.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    preserve_audit_schema_compatibility()
     print(
         f"observed ontology: curated={payload['curated_entry_count']} "
         f"observed={payload['observed_entity_count']} events={payload['source_event_count']} "

--- a/scripts/build_observed_ontology.py
+++ b/scripts/build_observed_ontology.py
@@ -70,6 +70,9 @@ def build() -> dict[str, Any]:
         rows.sort(key=lambda row: str(row.get("starts_at") or ""), reverse=True)
         first = rows[0]
         links: dict[str, dict[str, str]] = {}
+        ontology_ids = Counter(
+            str(row.get("ontology_id")) for row in rows if str(row.get("ontology_id") or "").strip()
+        )
         for row in rows:
             for candidate in row.get("official_links", []):
                 if not isinstance(candidate, dict):
@@ -107,6 +110,7 @@ def build() -> dict[str, Any]:
                 "dominant_category": dominant(category_distribution, len(rows)),
                 "subcategory_distribution": subcategory_distribution,
                 "event_mode_distribution": mode_distribution,
+                "matched_ontology_ids": dict(sorted(ontology_ids.items())),
                 "official_links": sorted(links.values(), key=lambda row: (row["kind"], row["url"])),
             }
         )
@@ -118,10 +122,12 @@ def build() -> dict[str, Any]:
         if isinstance(row, dict) and row.get("id")
     }
     return {
-        "schema_version": "3.0",
+        "schema_version": "3.1",
         "generated_at": now_iso(),
         "source_event_generated_at": event_doc.get("generated_at"),
         "source_event_count": int(event_doc.get("count") or len(events)),
+        "curated_schema_version": curated.get("schema_version"),
+        "governance": curated.get("governance", {}),
         "matching_policy": curated.get("matching_policy", {}),
         "curated_entry_count": len(curated.get("entries", [])),
         "observed_entity_count": len(observed),

--- a/tests/test_event_series_ontology.py
+++ b/tests/test_event_series_ontology.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+from cast_event_cal.ontology import enrich_event, validate_ontology
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_ontology() -> dict:
+    return json.loads((ROOT / "config" / "event_ontology.json").read_text(encoding="utf-8"))
+
+
+def test_series_ontology_is_human_curated_and_valid() -> None:
+    ontology = load_ontology()
+    validate_ontology(ontology)
+    governance = ontology["governance"]
+    assert governance["curation_mode"] == "human_only"
+    assert governance["automatic_entry_creation"] is False
+    assert governance["automatic_entry_rewrite"] is False
+    assert governance["observed_events_may_only_link_to_existing_entries"] is True
+
+
+def test_curated_entries_have_stable_profile_fields() -> None:
+    ontology = load_ontology()
+    assert ontology["schema_version"] == "2.0"
+    for entry in ontology["entries"]:
+        assert entry["schedule"]["type"] in {"recurring", "irregular", "one_off"}
+        assert entry["schedule"]["label"]
+        assert entry["schedule"]["cadence"]
+        assert entry["introduction"]
+        assert entry["highlights"]
+        assert entry["first_time_guide"]
+        assert entry["curation"]["status"] == "human_curated"
+        assert entry["curation"]["reviewed_at"]
+        assert all(url.startswith("https://") for url in entry["curation"]["sources"])
+
+
+def test_matched_event_receives_series_profile_and_keeps_announcement_first() -> None:
+    entry = load_ontology()["entries"][1]
+    event = {
+        "id": "example",
+        "title": "Cafe & Bar FOR LIGHT 営業告知",
+        "description": "本日の営業案内",
+        "organizer": "@FOR_LIGHT202209",
+        "url": "https://example.com/current-announcement",
+        "tags": ["VRChat"],
+    }
+    enriched = enrich_event(event, entry)
+    assert enriched["ontology_id"] == "cafe-bar-for-light"
+    assert enriched["series_profile"]["schedule"]["type"] == "recurring"
+    assert enriched["series_profile"]["introduction"] == entry["introduction"]
+    assert enriched["series_profile"]["highlights"] == entry["highlights"]
+    assert enriched["series_profile"]["first_time_guide"] == entry["first_time_guide"]
+    assert enriched["official_links"][0]["kind"] == "announcement"
+    assert enriched["official_links"][0]["url"] == event["url"]
+    assert any(link["kind"] == "official_x" for link in enriched["official_links"])
+    assert "定期開催" in enriched["tags"]

--- a/tests/test_pages_quality_view.py
+++ b/tests/test_pages_quality_view.py
@@ -10,9 +10,10 @@ def test_root_function_injects_only_first_party_assets() -> None:
     assert "context.next()" in source
     assert "HTMLRewriter" in source
     assert "x-quality-view" in source
-    assert "2026-08-04-quality-view-v5" in source
+    assert "2026-08-04-quality-view-v6" in source
     assert 'href="/uiux-v4.css"' in source
     assert 'src="/uiux-v4.js"' in source
+    assert 'src="/series-profile.js"' in source
     assert "https://" not in source
 
 
@@ -35,4 +36,15 @@ def test_quality_view_has_accessibility_mobile_and_density_contracts() -> None:
     assert "selectRange('today',false)" in script
     assert "applyPagination" in script
     assert "ux-filters-open" in script
+    assert "fetch(" not in script
+
+
+def test_series_profile_ui_uses_enriched_state_without_network_fetch() -> None:
+    script = (ROOT / "public" / "series-profile.js").read_text(encoding="utf-8")
+    assert "series_profile" in script
+    assert "CURATED SERIES PROFILE" in script
+    assert "初参加ガイド" in script
+    assert "人手で確認したオントロジー" in script
+    assert "MutationObserver" in script
+    assert "typeof state!=='undefined'" in script
     assert "fetch(" not in script


### PR DESCRIPTION
## Purpose

Increase the information density and appeal of recurring and irregular event listings without allowing ingestion results to rewrite the ontology.

## Architecture

- `config/event_ontology.json` is the human-curated source of truth
- search and ingestion may only link an observed event to an existing entry
- fuzzy matching, pattern-only matching, automatic entry creation, and automatic entry rewriting remain disabled
- matched events receive a stable `series_profile`; unmatched events remain unchanged

## Curated profile fields

- official website, VRChat Group, official X, participation guide, and other verified first-party links
- recurring / irregular / one-off schedule metadata
- stable introduction
- event highlights
- first-time guidance
- optional official image
- review status, date, and source URLs

## UI

Matched event cards show a curated series panel with cadence, introduction, highlights, first-time guidance, and review provenance. Official links remain separate buttons and the current announcement remains the primary action.

## Initial migration

- 0属オークション: irregular series profile
- Cafe & Bar FOR LIGHT: recurring series profile

## Validation

- Python module syntax checked for the rewritten ontology module
- strict ontology validation rejects non-human curation, automatic mutation, missing review sources, invalid schedule types, and non-HTTPS official links
- regression tests cover governance, profile enrichment, primary announcement ordering, and the no-fetch UI contract

Generated public data remains backward compatible: public event ontology schema stays at 3.0 and the audit schema stays at 2.0, while `curated_schema_version` identifies the new source schema.