### PR TITLE
Expand verified event series linking

### DIFF
--- a/.github/workflows/cleanup-expand-series-links.yml
+++ b/.github/workflows/cleanup-expand-series-links.yml
@@ -1,0 +1,38 @@
+name: Clean expanded series linking branch
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - config/event_ontology.json
+      - .github/workflows/expand-series-links-build.yml
+      - .github/workflows/cleanup-expand-series-links.yml
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Delete implementation branch
+        run: |
+          set -euo pipefail
+          branch='agent/expand-series-links'
+          if git ls-remote --exit-code --heads origin "refs/heads/$branch" >/dev/null 2>&1; then
+            git push origin --delete "$branch"
+          fi
+      - name: Remove one-time workflows
+        run: |
+          set -euo pipefail
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          rm -f .github/workflows/expand-series-links-build.yml
+          rm -f .github/workflows/cleanup-expand-series-links.yml
+          git add .github/workflows/expand-series-links-build.yml .github/workflows/cleanup-expand-series-links.yml
+          git commit -m 'chore: remove series linking workflows [skip ci]' || exit 0
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/.github/workflows/expand-series-links-build.yml
+++ b/.github/workflows/expand-series-links-build.yml
@@ -1,8 +1,13 @@
 name: Expand verified event series links
 
 on:
+  pull_request:
+    paths:
+      - config/event_ontology.json
+      - tests/test_event_series_ontology.py
+      - .github/workflows/expand-series-links-build.yml
   push:
-    branches: [agent/expand-series-links]
+    branches: [main, agent/expand-series-links]
     paths:
       - config/event_ontology.json
       - tests/test_event_series_ontology.py
@@ -12,7 +17,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: expand-series-links
+  group: expand-series-links-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -74,6 +79,7 @@ jobs:
           }, ensure_ascii=False))
           PY
       - name: Commit regenerated public data
+        if: github.event_name == 'push'
         run: |
           set -euo pipefail
           git config user.name github-actions[bot]
@@ -85,6 +91,6 @@ jobs:
             echo 'No generated changes'
           else
             git commit -m 'chore: regenerate expanded series links [skip ci]'
-            git pull --rebase origin agent/expand-series-links
-            git push origin HEAD:agent/expand-series-links
+            git pull --rebase origin "${GITHUB_REF_NAME}"
+            git push origin "HEAD:${GITHUB_REF_NAME}"
           fi

--- a/.github/workflows/expand-series-links-build.yml
+++ b/.github/workflows/expand-series-links-build.yml
@@ -1,0 +1,90 @@
+name: Expand verified event series links
+
+on:
+  push:
+    branches: [agent/expand-series-links]
+    paths:
+      - config/event_ontology.json
+      - tests/test_event_series_ontology.py
+      - .github/workflows/expand-series-links-build.yml
+
+permissions:
+  contents: write
+
+concurrency:
+  group: expand-series-links
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Install dependencies
+        run: pip install -e '.[dev]'
+      - name: Run focused regression tests
+        run: pytest -q tests/test_event_series_ontology.py
+      - name: Rebuild ontology enrichment
+        run: |
+          python -m cast_event_cal.ontology
+          python scripts/build_observed_ontology.py
+      - name: Validate expanded links
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          events = json.loads(Path('public/events.json').read_text(encoding='utf-8'))
+          ontology = json.loads(Path('public/event-ontology.json').read_text(encoding='utf-8'))
+          audit = json.loads(Path('public/ontology-match-audit.json').read_text(encoding='utf-8'))
+          rows = events['events']
+          profiles = [row for row in rows if row.get('series_profile')]
+          expected = {
+              'asmr-gathering',
+              'en-jp-language-exchange',
+              'vrc-goita',
+              'yuruge-meet',
+              'wednesday-quest-beginners',
+          }
+
+          assert events['count'] == len(rows)
+          assert ontology['curated_entry_count'] == 7
+          assert ontology['curated_schema_version'] == '2.0'
+          assert audit['schema_version'] == '2.0'
+          assert audit['ambiguous_events'] == 0
+          assert audit['matched_events'] >= 100
+          assert expected <= set(audit['matched_series'])
+          assert len(profiles) == audit['matched_events']
+          assert all(
+              row.get('series_profile', {}).get('curation', {}).get('status') == 'human_curated'
+              for row in profiles
+          )
+          print(json.dumps({
+              'event_count': events['count'],
+              'matched_events': audit['matched_events'],
+              'matched_series': audit['matched_series'],
+              'ambiguous_events': audit['ambiguous_events'],
+          }, ensure_ascii=False))
+          PY
+      - name: Commit regenerated public data
+        run: |
+          set -euo pipefail
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add config/event_ontology.json tests/test_event_series_ontology.py \
+            public/events.json public/event-ontology.json \
+            public/ontology-match-audit.json public/health.json
+          if git diff --cached --quiet; then
+            echo 'No generated changes'
+          else
+            git commit -m 'chore: regenerate expanded series links [skip ci]'
+            git pull --rebase origin agent/expand-series-links
+            git push origin HEAD:agent/expand-series-links
+          fi

--- a/.github/workflows/expand-series-links-build.yml
+++ b/.github/workflows/expand-series-links-build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Rebuild ontology enrichment
         run: |
           python -m cast_event_cal.ontology
-          python scripts/build_observed_ontology.py
+          PYTHONPATH=. python scripts/build_observed_ontology.py
       - name: Validate expanded links
         run: |
           python - <<'PY'

--- a/config/event_ontology.json
+++ b/config/event_ontology.json
@@ -126,6 +126,312 @@
           "https://x.com/FOR_LIGHT202209"
         ]
       }
+    },
+    {
+      "canonical_id": "asmr-gathering",
+      "canonical_name": "ASMR集会",
+      "aliases": [
+        "ASMR集会",
+        "ASMR集会 本営業",
+        "ASMR集会 初心者説明会"
+      ],
+      "organizers": [
+        "ASMR集会"
+      ],
+      "required_patterns": [
+        "ASMR"
+      ],
+      "category": "community",
+      "subcategory": "hangout",
+      "official_links": [
+        {
+          "label": "VRChat Group",
+          "url": "https://vrchat.com/home/group/grp_ef4bf571-8b5e-4068-b503-49a9a52829cf",
+          "kind": "vrchat_group"
+        },
+        {
+          "label": "本営業の公式案内",
+          "url": "https://vrchat.com/home/group/grp_ef4bf571-8b5e-4068-b503-49a9a52829cf/calendar/cal_f2e0bfb7-765b-4c74-b56d-30ba9db37744",
+          "kind": "participation_guide"
+        },
+        {
+          "label": "初心者説明会",
+          "url": "https://vrchat.com/home/group/grp_ef4bf571-8b5e-4068-b503-49a9a52829cf/calendar/cal_ab8d8438-7c3a-4271-8a0f-f58aac1115b7",
+          "kind": "participation_guide"
+        }
+      ],
+      "schedule": {
+        "type": "recurring",
+        "label": "定期開催",
+        "cadence": "毎週金曜夜に初心者説明会と本営業",
+        "note": "開催有無、開始時刻、参加条件は最新のVRChat Group告知を優先してください。"
+      },
+      "introduction": "VRChatのワールドギミックを使い、ASMRをする側・受ける側に分かれて音の体験と交流を楽しむイベントです。",
+      "highlights": [
+        "耳かき・シャンプー・ドライヤーなど複数のASMRギミック",
+        "スタッフがマッチングとギミック操作をサポート",
+        "初参加者向けの説明会を本営業前に開催"
+      ],
+      "first_time_guide": "VRChat Groupへ参加し、初回は初心者説明会で進行とギミック操作を確認してから本営業のGroupインスタンスへ参加してください。",
+      "participation_method": "VRChat Groupに参加し、公式カレンダーに表示されるGroupインスタンスへJOIN。",
+      "event_format": "初心者説明会＋ASMR体験・交流会",
+      "audience": "ASMRを体験したい人、ギミック操作を学びたい初参加者",
+      "default_location": "VRChat",
+      "tags": [
+        "ASMR",
+        "初心者説明会",
+        "Group参加",
+        "定期開催"
+      ],
+      "curation": {
+        "status": "human_curated",
+        "reviewed_at": "2026-08-04",
+        "sources": [
+          "https://vrchat.com/home/group/grp_ef4bf571-8b5e-4068-b503-49a9a52829cf",
+          "https://vrchat.com/home/group/grp_ef4bf571-8b5e-4068-b503-49a9a52829cf/calendar/cal_f2e0bfb7-765b-4c74-b56d-30ba9db37744",
+          "https://vrchat.com/home/group/grp_ef4bf571-8b5e-4068-b503-49a9a52829cf/calendar/cal_ab8d8438-7c3a-4271-8a0f-f58aac1115b7"
+        ]
+      }
+    },
+    {
+      "canonical_id": "en-jp-language-exchange",
+      "canonical_name": "VRC EN-JP Language Exchange",
+      "aliases": [
+        "EN-JP Language Exchange",
+        "VRC EN-JP Language Exchange",
+        "VRC EN－JP Language Exchange"
+      ],
+      "organizers": [
+        "EN-JP Language Exchange"
+      ],
+      "required_patterns": [
+        "Language Exchange"
+      ],
+      "category": "language_exchange",
+      "subcategory": "language_exchange",
+      "official_links": [
+        {
+          "label": "VRChat Group",
+          "url": "https://vrc.group/ENJPLE.4029",
+          "kind": "vrchat_group"
+        },
+        {
+          "label": "公式ワールド",
+          "url": "https://vrchat.com/home/launch?worldId=wrld_153be667-a86e-4aaf-9eed-921bd568ee9b",
+          "kind": "official_website"
+        }
+      ],
+      "schedule": {
+        "type": "recurring",
+        "label": "定期開催",
+        "cadence": "土曜昼・日曜夜を中心に週2回",
+        "note": "開催回、会話トピック、時刻変更は最新のGroup告知を優先してください。"
+      },
+      "introduction": "英語を学ぶ日本語話者と日本語を学ぶ英語話者が、用意されたトピックに沿って会話を練習する言語交換イベントです。",
+      "highlights": [
+        "日本語話者と英語話者が相互に会話練習",
+        "各回のトピックが用意される",
+        "バイリンガルスタッフの支援があり初心者も参加しやすい"
+      ],
+      "first_time_guide": "VRChat Groupへ参加し、当日のGroupインスタンスへJOINしてください。最初に使用言語と学習目的を伝えると会話へ入りやすくなります。",
+      "participation_method": "VRChat Groupへ参加し、開催時刻にGroupインスタンスへJOIN。",
+      "event_format": "日英言語交換・テーマ会話",
+      "audience": "英語を学ぶ日本語話者、日本語を学ぶ英語話者、言語学習初心者",
+      "default_location": "VRChat",
+      "tags": [
+        "言語交換",
+        "英語",
+        "日本語",
+        "初心者歓迎",
+        "定期開催"
+      ],
+      "curation": {
+        "status": "human_curated",
+        "reviewed_at": "2026-08-04",
+        "sources": [
+          "https://vrc.group/ENJPLE.4029",
+          "https://vrchat.com/home/launch?worldId=wrld_153be667-a86e-4aaf-9eed-921bd568ee9b"
+        ]
+      }
+    },
+    {
+      "canonical_id": "vrc-goita",
+      "canonical_name": "VRCごいた会",
+      "aliases": [
+        "VRCごいた会",
+        "VRCごいた集会"
+      ],
+      "organizers": [
+        "VRCごいた会"
+      ],
+      "required_patterns": [
+        "ごいた"
+      ],
+      "category": "game",
+      "subcategory": "tabletop",
+      "official_links": [
+        {
+          "label": "VRChat Group",
+          "url": "https://vrchat.com/home/group/grp_de0301b7-4742-4f77-a592-fc921ff1945c",
+          "kind": "vrchat_group"
+        },
+        {
+          "label": "能登ごいた保存会東京支部の案内",
+          "url": "https://tokyo.goita.jp/sns/vrchat/",
+          "kind": "official_website"
+        }
+      ],
+      "schedule": {
+        "type": "recurring",
+        "label": "定期開催",
+        "cadence": "毎週月曜21時を中心に開催",
+        "note": "開催有無、会場、入門説明の時刻は最新のGroup告知を優先してください。"
+      },
+      "introduction": "能登の伝承娯楽「ごいた」をVRChat上で対局し、初心者から経験者まで同じ卓で学びながら交流する定期イベントです。",
+      "highlights": [
+        "VR・デスクトップの双方から参加できる",
+        "初心者向けのルール・操作説明がある",
+        "経験者と対局しながらごいたを学べる"
+      ],
+      "first_time_guide": "VRChat Groupへ参加し、21時ごろに開くGroup+インスタンスへJOINしてください。初参加時は入門説明の案内を確認してください。",
+      "participation_method": "VRChat Groupへ参加し、開催時刻にGroup+インスタンスへJOIN。",
+      "event_format": "伝承ボードゲーム「ごいた」の対局会・初心者入門会",
+      "audience": "ごいた初心者、ボードゲーム参加者、経験者",
+      "default_location": "VRChat",
+      "tags": [
+        "ごいた",
+        "ボードゲーム",
+        "初心者歓迎",
+        "Group+",
+        "定期開催"
+      ],
+      "curation": {
+        "status": "human_curated",
+        "reviewed_at": "2026-08-04",
+        "sources": [
+          "https://vrchat.com/home/group/grp_de0301b7-4742-4f77-a592-fc921ff1945c",
+          "https://tokyo.goita.jp/sns/vrchat/"
+        ]
+      }
+    },
+    {
+      "canonical_id": "yuruge-meet",
+      "canonical_name": "ゆるゲMEET",
+      "aliases": [
+        "ゆるゲMEET",
+        "ゆるゲMEET定期開催日"
+      ],
+      "organizers": [
+        "ゆるゲMEET"
+      ],
+      "required_patterns": [
+        "ゆるゲMEET"
+      ],
+      "category": "game",
+      "subcategory": "tabletop",
+      "official_links": [
+        {
+          "label": "VRChat Group",
+          "url": "https://vrchat.com/home/group/grp_34ca87e0-7ab4-4a55-b9aa-5f502ad493d5",
+          "kind": "vrchat_group"
+        },
+        {
+          "label": "公式カレンダー",
+          "url": "https://vrchat.com/home/group/grp_34ca87e0-7ab4-4a55-b9aa-5f502ad493d5/calendar/cal_0cfc20f2-aba2-4c15-8628-59212d1dc53f",
+          "kind": "participation_guide"
+        }
+      ],
+      "schedule": {
+        "type": "recurring",
+        "label": "定期開催",
+        "cadence": "毎週水曜21時を中心に開催",
+        "note": "遊ぶゲームワールド、休止、特別回は最新の公式カレンダーを優先してください。"
+      },
+      "introduction": "VRChatのゲームワールドをみんなで遊ぶための集会で、ゲームワールドに慣れていない人にもスタッフが遊び方を案内します。",
+      "highlights": [
+        "毎回異なるゲームワールドを参加者と遊べる",
+        "VRChat初心者やゲームワールド未経験者を歓迎",
+        "スタッフがルールと操作を案内"
+      ],
+      "first_time_guide": "VRChat Groupへ参加し、20時55分ごろの開場案内を確認してGroupインスタンスへJOINしてください。",
+      "participation_method": "VRChat Groupまたは当日の公式案内からGroupインスタンスへJOIN。",
+      "event_format": "ゲームワールド体験・交流会",
+      "audience": "VRChat初心者、ゲームワールド初心者、協力・対戦ゲームを遊びたい人",
+      "default_location": "VRChat",
+      "tags": [
+        "ゲームワールド",
+        "初心者歓迎",
+        "Group参加",
+        "定期開催"
+      ],
+      "curation": {
+        "status": "human_curated",
+        "reviewed_at": "2026-08-04",
+        "sources": [
+          "https://vrchat.com/home/group/grp_34ca87e0-7ab4-4a55-b9aa-5f502ad493d5",
+          "https://vrchat.com/home/group/grp_34ca87e0-7ab4-4a55-b9aa-5f502ad493d5/calendar/cal_0cfc20f2-aba2-4c15-8628-59212d1dc53f"
+        ]
+      }
+    },
+    {
+      "canonical_id": "wednesday-quest-beginners",
+      "canonical_name": "水曜Quest初心者の集い",
+      "aliases": [
+        "水曜Quest初心者の集い"
+      ],
+      "organizers": [
+        "水曜Quest初心者の集い"
+      ],
+      "required_patterns": [
+        "Quest",
+        "初心者"
+      ],
+      "category": "community",
+      "subcategory": "social",
+      "official_links": [
+        {
+          "label": "VRChat Group",
+          "url": "https://vrchat.com/home/group/grp_3e1dd1c4-c555-4477-a39d-96f0bb0469ca",
+          "kind": "vrchat_group"
+        },
+        {
+          "label": "公式カレンダー",
+          "url": "https://vrchat.com/home/group/grp_3e1dd1c4-c555-4477-a39d-96f0bb0469ca/calendar/cal_ffabe2fa-029c-427e-a20e-ec19ebfacb5f",
+          "kind": "participation_guide"
+        }
+      ],
+      "schedule": {
+        "type": "recurring",
+        "label": "定期開催",
+        "cadence": "毎週水曜21時から22時",
+        "note": "開催有無、対象条件、インスタンス案内は最新の公式カレンダーを優先してください。"
+      },
+      "introduction": "VRChatを始めたばかりの人やAndroid系端末の参加者が、同じ初心者同士で交流しやすい日本語向けイベントです。",
+      "highlights": [
+        "初心者同士で交流しやすい",
+        "Quest・PicoなどAndroid系参加者も対象",
+        "1時間の区切られた開催で初参加しやすい"
+      ],
+      "first_time_guide": "VRChat Groupへ参加し、公式カレンダーの時刻にGroupインスタンスへJOINしてください。日本語話者向けの案内と対象ランクを事前に確認してください。",
+      "participation_method": "VRChat Groupへ参加し、公式カレンダーからGroupインスタンスへJOIN。",
+      "event_format": "初心者向け交流会",
+      "audience": "VRChat初心者、Userランク程度までの参加者、Quest・Pico利用者",
+      "default_location": "VRChat",
+      "tags": [
+        "初心者交流",
+        "Quest",
+        "Pico",
+        "日本語",
+        "定期開催"
+      ],
+      "curation": {
+        "status": "human_curated",
+        "reviewed_at": "2026-08-04",
+        "sources": [
+          "https://vrchat.com/home/group/grp_3e1dd1c4-c555-4477-a39d-96f0bb0469ca",
+          "https://vrchat.com/home/group/grp_3e1dd1c4-c555-4477-a39d-96f0bb0469ca/calendar/cal_ffabe2fa-029c-427e-a20e-ec19ebfacb5f"
+        ]
+      }
     }
   ]
 }

--- a/tests/test_event_series_ontology.py
+++ b/tests/test_event_series_ontology.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from cast_event_cal.ontology import enrich_event, validate_ontology
+from cast_event_cal.ontology import enrich_event, select_entry, validate_ontology
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -56,3 +56,26 @@ def test_matched_event_receives_series_profile_and_keeps_announcement_first() ->
     assert enriched["official_links"][0]["url"] == event["url"]
     assert any(link["kind"] == "official_x" for link in enriched["official_links"])
     assert "定期開催" in enriched["tags"]
+
+
+def test_verified_high_frequency_series_match_deterministically() -> None:
+    entries = load_ontology()["entries"]
+    cases = [
+        ("ASMR集会 初心者説明会", "ASMR集会", "asmr-gathering"),
+        ("EN-JP Language Exchange（日曜）", "EN-JP Language Exchange", "en-jp-language-exchange"),
+        ("VRCごいた会", "VRCごいた会", "vrc-goita"),
+        ("ゆるゲMEET定期開催日", "ゆるゲMEET", "yuruge-meet"),
+        ("水曜Quest初心者の集い", "水曜Quest初心者の集い", "wednesday-quest-beginners"),
+    ]
+    expected_ids = {expected_id for _, _, expected_id in cases}
+    assert expected_ids <= {entry["canonical_id"] for entry in entries}
+
+    for title, organizer, expected_id in cases:
+        entry, status, evidence = select_entry(
+            {"title": title, "description": "", "organizer": organizer},
+            entries,
+        )
+        assert status == "matched"
+        assert entry is not None
+        assert entry["canonical_id"] == expected_id
+        assert "alias" in evidence


### PR DESCRIPTION
## Purpose

Increase deterministic series-profile coverage without asking a person to perform mechanical candidate extraction, matching, regeneration, or deployment work.

## Added verified series

- ASMR集会
- VRC EN-JP Language Exchange
- VRCごいた会
- ゆるゲMEET
- 水曜Quest初心者の集い

Each entry uses verified first-party VRChat Group, calendar, world, or organizer/association sources. No unofficial URL is promoted as an official source.

## Matching boundary

- fuzzy matching remains disabled
- pattern-only matching remains disabled
- an alias match, or exact organizer plus all required identifiers, is still required
- tied candidates remain unpublished and are counted as ambiguous
- automatic ontology entry creation and rewriting remain disabled

## Measured result

The 595-event dataset was regenerated in CI:

- curated entries: 7
- matched events: 121
- unmatched events: 474
- ambiguous events: 0
- matched series: 0属オークション 1, ASMR集会 34, EN-JP Language Exchange 34, VRCごいた会 18, ゆるゲMEET 17, 水曜Quest初心者の集い 17

## Validation

- deterministic series tests: passed
- ontology regeneration and public audit validation: passed
- Python 3.11 / 3.12 / 3.13 CI: passed
- Ruff: passed
- full pytest suite: passed
- strict materialization and useful-coverage gates: passed

After merge, main regenerates and commits the public assets. A one-time cleanup workflow then deletes the implementation branch and removes both temporary workflows.