### PR TITLE
Audit daily registration count changes

### DIFF
--- a/.github/workflows/registration-count-audit.yml
+++ b/.github/workflows/registration-count-audit.yml
@@ -1,0 +1,61 @@
+name: Audit registration counts
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '7 21 * * *'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cast-event-registration-count-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Install dependencies
+        run: pip install -e '.[dev]'
+      - name: Test count audit
+        run: pytest -q tests/test_registration_count_audit.py
+      - name: Build count audit
+        run: python scripts/build_registration_count_audit.py
+      - name: Validate count audit
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path('public/registration-count-audit.json').read_text(encoding='utf-8'))
+          assert payload['schema_version'] == '1.0'
+          assert payload['status'] == 'ok'
+          assert payload['snapshot_count'] == len(payload['snapshots'])
+          assert payload['snapshot_count'] >= 1
+          latest = payload['latest']
+          assert latest['calendar_event_count'] >= 0
+          assert latest['yahoo_candidate_count'] == latest['yahoo_accepted_count'] + latest['yahoo_rejected_count']
+          assert latest['yahoo_queries_failed'] == 0
+          PY
+      - name: Commit audit snapshot
+        run: |
+          set -euo pipefail
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add public/registration-count-audit.json
+          if git diff --cached --quiet; then
+            echo 'No registration count change'
+          else
+            git commit -m 'chore: record registration count audit [skip ci]'
+            git pull --rebase origin main
+            git push origin HEAD:main
+          fi

--- a/scripts/build_registration_count_audit.py
+++ b/scripts/build_registration_count_audit.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+CALENDAR_HEALTH = Path("public/health.json")
+YAHOO_HEALTH = Path("data/yahoo_realtime_health.json")
+OUTPUT = Path("public/registration-count-audit.json")
+MAX_SNAPSHOTS = 90
+
+
+def read_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def integer(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ValueError("boolean is not a count")
+    return int(value)
+
+
+def snapshot(calendar: dict[str, Any], yahoo: dict[str, Any]) -> dict[str, Any]:
+    sources = {
+        str(row.get("name")): integer(row.get("count", 0))
+        for row in calendar.get("sources", [])
+        if isinstance(row, dict) and row.get("name")
+    }
+    return {
+        "generated_at": str(calendar["generated_at"]),
+        "calendar_event_count": integer(calendar["event_count"]),
+        "source_counts": sources,
+        "yahoo_candidate_count": integer(yahoo["history_candidate_count"]),
+        "yahoo_accepted_count": integer(yahoo["history_accepted_count"]),
+        "yahoo_rejected_count": integer(yahoo["history_rejected_count"]),
+        "yahoo_unique_candidates_this_run": integer(yahoo.get("unique_candidates_this_run", 0)),
+        "yahoo_queries_succeeded": integer(yahoo.get("queries_succeeded", 0)),
+        "yahoo_queries_failed": integer(yahoo.get("queries_failed", 0)),
+    }
+
+
+def delta(current: dict[str, Any], previous: dict[str, Any] | None) -> dict[str, Any] | None:
+    if previous is None:
+        return None
+    source_names = sorted(set(previous.get("source_counts", {})) | set(current.get("source_counts", {})))
+    return {
+        "from_generated_at": previous["generated_at"],
+        "calendar_event_count": current["calendar_event_count"] - previous["calendar_event_count"],
+        "source_counts": {
+            name: current.get("source_counts", {}).get(name, 0)
+            - previous.get("source_counts", {}).get(name, 0)
+            for name in source_names
+        },
+        "yahoo_candidate_count": current["yahoo_candidate_count"] - previous["yahoo_candidate_count"],
+        "yahoo_accepted_count": current["yahoo_accepted_count"] - previous["yahoo_accepted_count"],
+        "yahoo_rejected_count": current["yahoo_rejected_count"] - previous["yahoo_rejected_count"],
+    }
+
+
+def build() -> dict[str, Any]:
+    calendar = read_json(CALENDAR_HEALTH, {})
+    yahoo = read_json(YAHOO_HEALTH, {})
+    if calendar.get("status") != "ok":
+        raise ValueError("calendar health must be ok")
+    if yahoo.get("status") != "ok":
+        raise ValueError("Yahoo health must be ok")
+
+    current = snapshot(calendar, yahoo)
+    existing = read_json(OUTPUT, {})
+    snapshots = [row for row in existing.get("snapshots", []) if isinstance(row, dict)]
+    snapshots = [row for row in snapshots if row.get("generated_at") != current["generated_at"]]
+    previous = snapshots[-1] if snapshots else None
+    current["delta_from_previous"] = delta(current, previous)
+    snapshots.append(current)
+    snapshots = snapshots[-MAX_SNAPSHOTS:]
+
+    return {
+        "schema_version": "1.0",
+        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "status": "ok",
+        "snapshot_count": len(snapshots),
+        "latest": current,
+        "snapshots": snapshots,
+    }
+
+
+def main() -> int:
+    payload = build()
+    OUTPUT.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(payload["latest"], ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_registration_count_audit.py
+++ b/tests/test_registration_count_audit.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import build_registration_count_audit as audit
+
+
+def test_build_appends_snapshot_and_computes_deltas(tmp_path, monkeypatch):
+    calendar = tmp_path / "health.json"
+    yahoo = tmp_path / "yahoo.json"
+    output = tmp_path / "audit.json"
+    calendar.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-08-05T00:00:00Z",
+                "status": "ok",
+                "event_count": 610,
+                "sources": [
+                    {"name": "repository_manual_events", "count": 499},
+                    {"name": "yahoo_realtime_events", "count": 470},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    yahoo.write_text(
+        json.dumps(
+            {
+                "status": "ok",
+                "history_candidate_count": 3000,
+                "history_accepted_count": 470,
+                "history_rejected_count": 2530,
+                "unique_candidates_this_run": 70,
+                "queries_succeeded": 22,
+                "queries_failed": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    output.write_text(
+        json.dumps(
+            {
+                "snapshots": [
+                    {
+                        "generated_at": "2026-08-04T00:00:00Z",
+                        "calendar_event_count": 600,
+                        "source_counts": {
+                            "repository_manual_events": 499,
+                            "yahoo_realtime_events": 466,
+                        },
+                        "yahoo_candidate_count": 2930,
+                        "yahoo_accepted_count": 466,
+                        "yahoo_rejected_count": 2464,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(audit, "CALENDAR_HEALTH", calendar)
+    monkeypatch.setattr(audit, "YAHOO_HEALTH", yahoo)
+    monkeypatch.setattr(audit, "OUTPUT", output)
+
+    payload = audit.build()
+    latest = payload["latest"]
+    assert latest["delta_from_previous"]["calendar_event_count"] == 10
+    assert latest["delta_from_previous"]["yahoo_candidate_count"] == 70
+    assert latest["delta_from_previous"]["yahoo_accepted_count"] == 4
+    assert latest["delta_from_previous"]["yahoo_rejected_count"] == 66
+    assert latest["delta_from_previous"]["source_counts"]["yahoo_realtime_events"] == 4
+
+
+def test_build_rejects_unhealthy_inputs(tmp_path, monkeypatch):
+    calendar = tmp_path / "health.json"
+    yahoo = tmp_path / "yahoo.json"
+    calendar.write_text(json.dumps({"status": "degraded"}), encoding="utf-8")
+    yahoo.write_text(json.dumps({"status": "ok"}), encoding="utf-8")
+    monkeypatch.setattr(audit, "CALENDAR_HEALTH", calendar)
+    monkeypatch.setattr(audit, "YAHOO_HEALTH", yahoo)
+    try:
+        audit.build()
+    except ValueError as exc:
+        assert "calendar health" in str(exc)
+    else:
+        raise AssertionError("unhealthy input must fail closed")

--- a/tests/test_registration_count_audit.py
+++ b/tests/test_registration_count_audit.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 from scripts import build_registration_count_audit as audit
 


### PR DESCRIPTION
## Purpose

Record daily changes in calendar registrations and Yahoo candidate classification counts instead of relying on point-in-time health files.

## Changes

- add `scripts/build_registration_count_audit.py`
- append up to 90 snapshots to `public/registration-count-audit.json`
- record total calendar events, per-source counts, Yahoo candidates, accepted, rejected, current-run unique candidates, and query success/failure counts
- compute deltas from the previous snapshot
- fail closed when either calendar or Yahoo health is not `ok`
- run daily at 06:07 JST, after the production calendar workflow scheduled for 05:17 JST
- add focused regression tests and consistency validation

## Current observed change

Between the 2026-08-03 23:28 UTC and 2026-08-04 22:00 UTC generated states:

- calendar events: 589 -> 600 (+11)
- Yahoo retained candidates: 2770 -> 2930 (+160)
- Yahoo accepted: 447 -> 466 (+19)
- Yahoo rejected: 2323 -> 2464 (+141)
- ontology matched events: 1 -> 278, reflecting the separately expanded curated ontology

The audit records counts and deltas only; it does not alter ingestion or classification rules.