### PR TITLE
Publish audited event API distributions and verified source snapshots

### DIFF
--- a/.github/workflows/public-api-v1.yml
+++ b/.github/workflows/public-api-v1.yml
@@ -1,0 +1,73 @@
+name: Public API v1
+
+on:
+  pull_request:
+    paths:
+      - "public/events.json"
+      - "scripts/build_public_api.py"
+      - "tests/test_build_public_api.py"
+      - "scripts/audit_public_feed.py"
+      - ".github/workflows/public-api-v1.yml"
+  push:
+    branches: [main]
+    paths:
+      - "public/events.json"
+      - "scripts/build_public_api.py"
+      - "tests/test_build_public_api.py"
+      - "scripts/audit_public_feed.py"
+      - ".github/workflows/public-api-v1.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-api-v1-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff check scripts/build_public_api.py tests/test_build_public_api.py scripts/audit_public_feed.py
+      - run: pytest -q tests/test_build_public_api.py tests/test_audit_public_feed.py
+      - run: python scripts/build_public_api.py --output-dir build/api/v1
+      - run: python scripts/audit_public_feed.py build/api/v1/events.json --report build/api-audit.json
+      - name: Verify manifest checksums and row counts
+        run: |
+          python - <<'PY'
+          import csv
+          import hashlib
+          import json
+          from pathlib import Path
+
+          root = Path('build/api/v1')
+          manifest = json.loads((root / 'manifest.json').read_text(encoding='utf-8'))
+          feed = json.loads((root / 'events.json').read_text(encoding='utf-8'))
+          assert manifest['event_count'] == feed['count'] == len(feed['events'])
+          with (root / 'events.csv').open(encoding='utf-8', newline='') as fh:
+              assert sum(1 for _ in csv.DictReader(fh)) == manifest['event_count']
+          for name, meta in manifest['files'].items():
+              path = root / name
+              assert path.stat().st_size == meta['bytes']
+              assert hashlib.sha256(path.read_bytes()).hexdigest() == meta['sha256']
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cast-event-api-v1
+          path: build/api/v1
+          retention-days: 30
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cast-event-api-v1-audit
+          path: build/api-audit.json
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/public-feed-integrity.yml
+++ b/.github/workflows/public-feed-integrity.yml
@@ -1,0 +1,46 @@
+name: Public feed integrity
+
+on:
+  pull_request:
+    paths:
+      - "public/events.json"
+      - "scripts/audit_public_feed.py"
+      - "tests/test_audit_public_feed.py"
+      - ".github/workflows/public-feed-integrity.yml"
+  push:
+    branches: [main]
+    paths:
+      - "public/events.json"
+      - "scripts/audit_public_feed.py"
+      - "tests/test_audit_public_feed.py"
+      - ".github/workflows/public-feed-integrity.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-feed-integrity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: python -m pip install -e ".[dev]"
+      - run: ruff check scripts/audit_public_feed.py tests/test_audit_public_feed.py
+      - run: pytest tests/test_audit_public_feed.py
+      - run: python scripts/audit_public_feed.py public/events.json --report build/public-feed-audit.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: public-feed-audit
+          path: build/public-feed-audit.json
+          retention-days: 14
+          if-no-files-found: error

--- a/data/source_snapshots/vrchat-calendar-2026-08-07.json
+++ b/data/source_snapshots/vrchat-calendar-2026-08-07.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.0",
+  "retrieved_at": "2026-08-07",
+  "source": "VRChat public group calendar pages",
+  "license_note": "Event facts and source URLs only; event descriptions are not redistributed verbatim.",
+  "records": [
+    {
+      "calendar_id": "cal_0a0f7c7d-3f18-4fb4-859e-c89a05c31097",
+      "group_id": "grp_fdc62cb2-130c-4425-a5b9-95e4efd43d11",
+      "title": "Pyropaw Pyrocon Showcase",
+      "starts_at": "2026-08-15T23:00:00Z",
+      "ends_at": "2026-08-16T03:30:00Z",
+      "visibility": "public",
+      "source_url": "https://vrchat.com/home/group/grp_fdc62cb2-130c-4425-a5b9-95e4efd43d11/calendar/cal_0a0f7c7d-3f18-4fb4-859e-c89a05c31097"
+    },
+    {
+      "calendar_id": "cal_ffabe2fa-029c-427e-a20e-ec19ebfacb5f",
+      "group_id": "grp_3e1dd1c4-c555-4477-a39d-96f0bb0469ca",
+      "title": "水曜Quest初心者の集い",
+      "starts_at": "2026-11-18T12:00:00Z",
+      "ends_at": "2026-11-18T13:00:00Z",
+      "visibility": "public",
+      "repeating": true,
+      "language": "Japanese",
+      "source_url": "https://vrchat.com/home/group/grp_3e1dd1c4-c555-4477-a39d-96f0bb0469ca/calendar/cal_ffabe2fa-029c-427e-a20e-ec19ebfacb5f"
+    },
+    {
+      "calendar_id": "cal_7bf39952-a3b2-45f8-923e-08d8535749b9",
+      "group_id": "grp_d66fc7e0-955b-42aa-9abb-372bc72c178f",
+      "title": "VRTon 2026",
+      "starts_at": "2026-11-06T23:00:00Z",
+      "ends_at": "2026-11-08T03:00:00Z",
+      "source_url": "https://vrchat.com/home/group/grp_d66fc7e0-955b-42aa-9abb-372bc72c178f/calendar/cal_7bf39952-a3b2-45f8-923e-08d8535749b9"
+    }
+  ]
+}

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -1,0 +1,34 @@
+# Event API v1
+
+`public/events.json` を正準公開フィードとして、`scripts/build_public_api.py` が機械利用向けの配布物を生成します。
+
+生成先:
+
+- `public/api/v1/events.json` — 正準JSONのバージョン付きコピー
+- `public/api/v1/events.csv` — 主要列の表形式配布
+- `public/api/v1/facets.json` — category/status/source/event_mode の件数集計
+- `public/api/v1/manifest.json` — 件数、生成日時、source SHA-256、各配布物のSHA-256とbyte数
+
+## 利用例
+
+```bash
+python scripts/build_public_api.py
+python scripts/audit_public_feed.py public/api/v1/events.json --report build/api-audit.json
+```
+
+Pages配信後は次のURL体系を使用します。
+
+```text
+https://kafka2306.github.io/vrc_cast_event_calender/api/v1/manifest.json
+https://kafka2306.github.io/vrc_cast_event_calender/api/v1/events.json
+https://kafka2306.github.io/vrc_cast_event_calender/api/v1/events.csv
+https://kafka2306.github.io/vrc_cast_event_calender/api/v1/facets.json
+```
+
+クライアントは `manifest.json` の `source_sha256` またはファイル別 `sha256` を比較し、変更がない場合は再取得を省略できます。`cache.max_age_seconds` は再検証間隔の目安であり、完全な鮮度保証ではありません。
+
+CSVは検索・表計算向けの主要列だけを収録します。`official_links`、画像来歴、分類根拠などの詳細属性が必要な場合はJSONを使用してください。
+
+## 出典と更新
+
+イベントごとの出典は各レコードの `source`、`source_id`、`url`、`official_links` 等に保持します。公式VRChatカレンダーを人手確認した観測は `data/source_snapshots/` に取得日付きで保存します。本文の転載ではなく、日時・ID・タイトル・公開URLなど検証に必要な事実メタデータだけを保持します。

--- a/scripts/audit_public_feed.py
+++ b/scripts/audit_public_feed.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "cast-event-cal.public-feed-audit.v1"
+
+
+def _load(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _event_list(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        events = payload
+    elif isinstance(payload, dict) and isinstance(payload.get("events"), list):
+        events = payload["events"]
+    else:
+        raise ValueError("events.json must be a JSON array or an object with an events array")
+    if not all(isinstance(item, dict) for item in events):
+        raise ValueError("every event must be a JSON object")
+    return events
+
+
+def _identity(event: dict[str, Any]) -> str | None:
+    for key in ("id", "event_id", "uid", "canonical_id"):
+        value = event.get(key)
+        if isinstance(value, (str, int)) and str(value).strip():
+            return f"{key}:{str(value).strip()}"
+    url = event.get("url") or event.get("source_url") or event.get("official_url")
+    start = event.get("start") or event.get("start_at") or event.get("start_datetime")
+    title = event.get("title") or event.get("name")
+    if all(isinstance(value, str) and value.strip() for value in (url, start, title)):
+        return "fallback:" + "|".join(value.strip() for value in (url, start, title))
+    return None
+
+
+def _parse_datetime(value: str) -> bool:
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        datetime.fromisoformat(normalized)
+    except ValueError:
+        return False
+    return True
+
+
+def audit(path: Path) -> dict[str, Any]:
+    payload = _load(path)
+    events = _event_list(payload)
+    errors: list[dict[str, Any]] = []
+    identities: list[str] = []
+
+    for index, event in enumerate(events):
+        identity = _identity(event)
+        if identity is None:
+            errors.append({"index": index, "code": "missing_identity", "message": "event has no stable identity"})
+        else:
+            identities.append(identity)
+
+        title = event.get("title") or event.get("name")
+        if not isinstance(title, str) or not title.strip():
+            errors.append({"index": index, "code": "missing_title", "message": "event title is empty"})
+
+        for key in ("start", "start_at", "start_datetime"):
+            if key in event:
+                value = event[key]
+                if not isinstance(value, str) or not _parse_datetime(value):
+                    errors.append({"index": index, "code": "invalid_datetime", "field": key, "message": "datetime is not ISO-8601"})
+                break
+
+        for key in ("url", "source_url", "official_url"):
+            if key in event:
+                value = event[key]
+                if value is not None and (not isinstance(value, str) or not value.startswith(("https://", "http://"))):
+                    errors.append({"index": index, "code": "invalid_url", "field": key, "message": "URL must be absolute HTTP(S)"})
+
+    for identity, count in sorted(Counter(identities).items()):
+        if count > 1:
+            errors.append({"code": "duplicate_identity", "identity": identity, "count": count})
+
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "input": str(path),
+        "sha256": digest,
+        "event_count": len(events),
+        "unique_identity_count": len(set(identities)),
+        "error_count": len(errors),
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit the published event feed without network access")
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+    report = audit(args.path)
+    text = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 1 if report["error_count"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_public_api.py
+++ b/scripts/build_public_api.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+API_SCHEMA = "cast-event-cal.api.v1"
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _events(payload: Any) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    if not isinstance(payload, dict) or not isinstance(payload.get("events"), list):
+        raise ValueError("public/events.json must be an object with an events array")
+    rows = payload["events"]
+    if not all(isinstance(row, dict) for row in rows):
+        raise ValueError("every event must be an object")
+    if payload.get("count") != len(rows):
+        raise ValueError("count does not match events length")
+    return payload, rows
+
+
+def build(source: Path, output_dir: Path) -> dict[str, Any]:
+    payload, rows = _events(json.loads(source.read_text(encoding="utf-8")))
+    ids = [str(row.get("id", "")).strip() for row in rows]
+    if any(not value for value in ids) or len(ids) != len(set(ids)):
+        raise ValueError("event ids must be non-empty and unique")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    api_events = output_dir / "events.json"
+    api_csv = output_dir / "events.csv"
+    facets_path = output_dir / "facets.json"
+    manifest_path = output_dir / "manifest.json"
+
+    _write_json(api_events, payload)
+
+    fields = ["id", "title", "starts_at", "ends_at", "organizer", "location", "category", "status", "source", "url", "fetched_at"]
+    with api_csv.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fields)
+        writer.writeheader()
+        for row in sorted(rows, key=lambda item: (str(item.get("starts_at") or ""), str(item.get("id") or ""))):
+            writer.writerow({key: row.get(key) for key in fields})
+
+    facet_fields = ("category", "status", "source", "event_mode")
+    facets = {
+        field: dict(sorted(Counter(str(row.get(field)) for row in rows if row.get(field) is not None).items()))
+        for field in facet_fields
+    }
+    _write_json(facets_path, {"schema_version": API_SCHEMA, "event_count": len(rows), "facets": facets})
+
+    files = {}
+    for path in (api_events, api_csv, facets_path):
+        files[path.name] = {"bytes": path.stat().st_size, "sha256": _sha256(path)}
+
+    manifest = {
+        "schema_version": API_SCHEMA,
+        "source_schema_version": payload.get("schema_version"),
+        "generated_at": payload.get("generated_at"),
+        "timezone": payload.get("timezone"),
+        "event_count": len(rows),
+        "source_sha256": _sha256(source),
+        "cache": {"max_age_seconds": 900, "validation": "sha256"},
+        "files": files,
+    }
+    _write_json(manifest_path, manifest)
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build versioned JSON/CSV/facet distributions for the public event feed")
+    parser.add_argument("--source", type=Path, default=Path("public/events.json"))
+    parser.add_argument("--output-dir", type=Path, default=Path("public/api/v1"))
+    args = parser.parse_args()
+    manifest = build(args.source, args.output_dir)
+    print(json.dumps(manifest, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_public_feed.py
+++ b/tests/test_audit_public_feed.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.audit_public_feed import audit
+
+
+def _write(tmp_path: Path, payload: object) -> Path:
+    path = tmp_path / "events.json"
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def test_valid_feed_has_no_errors(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {
+                "id": "event-1",
+                "title": "Event One",
+                "start": "2026-08-06T20:00:00+09:00",
+                "url": "https://example.com/event-1",
+            }
+        ],
+    )
+    report = audit(path)
+    assert report["event_count"] == 1
+    assert report["unique_identity_count"] == 1
+    assert report["error_count"] == 0
+    assert len(report["sha256"]) == 64
+
+
+def test_duplicate_identity_is_rejected(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [
+            {"id": "same", "title": "A"},
+            {"id": "same", "title": "B"},
+        ],
+    )
+    report = audit(path)
+    assert any(error["code"] == "duplicate_identity" for error in report["errors"])
+
+
+def test_missing_identity_and_bad_fields_are_reported(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        [{"title": "", "start": "not-a-date", "url": "relative/path"}],
+    )
+    codes = {error["code"] for error in audit(path)["errors"]}
+    assert {"missing_identity", "missing_title", "invalid_datetime", "invalid_url"} <= codes

--- a/tests/test_build_public_api.py
+++ b/tests/test_build_public_api.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from pathlib import Path
+
+from scripts.build_public_api import build
+
+
+def test_build_public_api_outputs_consistent_files(tmp_path: Path) -> None:
+    source = tmp_path / "events.json"
+    source.write_text(
+        json.dumps(
+            {
+                "schema_version": "2.0",
+                "generated_at": "2026-08-07T12:00:00Z",
+                "timezone": "Asia/Tokyo",
+                "count": 2,
+                "events": [
+                    {"id": "b", "title": "B", "starts_at": "2026-08-09T00:00:00Z", "category": "music", "status": "scheduled", "source": "official"},
+                    {"id": "a", "title": "A", "starts_at": "2026-08-08T00:00:00Z", "category": "community", "status": "scheduled", "source": "official"},
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "api" / "v1"
+    manifest = build(source, output)
+    assert manifest["event_count"] == 2
+    assert manifest["source_sha256"] == hashlib.sha256(source.read_bytes()).hexdigest()
+    events = json.loads((output / "events.json").read_text(encoding="utf-8"))
+    assert events["count"] == 2
+    facets = json.loads((output / "facets.json").read_text(encoding="utf-8"))
+    assert facets["facets"]["category"] == {"community": 1, "music": 1}
+    with (output / "events.csv").open(encoding="utf-8", newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    assert [row["id"] for row in rows] == ["a", "b"]
+    for name, meta in manifest["files"].items():
+        path = output / name
+        assert meta["bytes"] == path.stat().st_size
+        assert meta["sha256"] == hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_duplicate_ids_fail_closed(tmp_path: Path) -> None:
+    source = tmp_path / "events.json"
+    source.write_text(json.dumps({"count": 2, "events": [{"id": "x"}, {"id": "x"}]}), encoding="utf-8")
+    try:
+        build(source, tmp_path / "out")
+    except ValueError as exc:
+        assert "unique" in str(exc)
+    else:
+        raise AssertionError("duplicate ids must be rejected")


### PR DESCRIPTION
## 目的

公開イベントDBを、単なる品質ゲート追加ではなく、検証可能な機械配布基盤へ拡張します。既存の `public/events.json` / Web UI / 収集パイプラインは維持し、後方互換のJSON・CSV・facet・manifest配布と公式ソース観測履歴を追加します。

## 実データと来歴

- 現行 `public/events.json`: 613イベント、schema 2.0、生成日時 `2026-08-05T21:59:58Z`
- 2026-08-07にVRChat公式Group Calendarで将来イベント3件を再確認し、`data/source_snapshots/vrchat-calendar-2026-08-07.json` に事実メタデータと公式URLを保存
- 公式説明本文は転載せず、calendar/group ID、タイトル、開始終了日時、公開属性等だけを保持
- 既存正準データへ安全に重複判定できない観測を強制挿入せず、provenance snapshotとして分離

## API配布

`scripts/build_public_api.py` を追加し、正準 `public/events.json` から決定的に次を生成します。

- `events.json`
- `events.csv`
- `facets.json`（category/status/source/event_mode）
- `manifest.json`（件数、source SHA-256、各配布物のbyte数/SHA-256、cache検証情報）

IDは非空・一意を必須とし、`count == len(events)` を強制します。CSVは `starts_at,id` 順で安定生成します。

## 品質・CI

- `scripts/audit_public_feed.py`: 重複ID、空タイトル、不正日時、不正URLをfail-closed監査
- `tests/test_audit_public_feed.py`: 監査回帰テスト
- `tests/test_build_public_api.py`: JSON/CSV/facet/manifest整合、checksum、byte数、重複ID拒否を検証
- `Public feed integrity`: 正準公開feedを独立監査
- `Public API v1`: API生成、ruff、pytest、CSV件数、manifest件数、SHA-256、byte数を検証し、30日artifact配布
- 通常CI: Python 3.11/3.12/3.13で全テスト、validation、credential-free fallback、strict buildを実行

## 利用方法

`docs/api-v1.md` にデータ辞書、生成方法、SHA-256による差分同期、JSON/CSVの使い分けを記載しています。

## 後方互換性

既存 `public/events.json` のschemaやURL、Web UI、既存収集処理は変更しません。API v1は追加レイヤーです。恒久Pages URLへの同期は、配信先リポジトリ側のデプロイ確認ができるまで公開済みとは扱いません。