### PR TITLE
Add canonical read-only Event MCP with provenance

### DIFF
--- a/cast_event_cal/mcp_read_model.py
+++ b/cast_event_cal/mcp_read_model.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLIC = ROOT / "public"
+JST = ZoneInfo("Asia/Tokyo")
+MAX_LIMIT = 100
+
+
+def _load_json(name: str) -> Any:
+    return json.loads((PUBLIC / name).read_text(encoding="utf-8"))
+
+
+def _events_payload() -> dict[str, Any]:
+    payload = _load_json("events.json")
+    if not isinstance(payload, dict) or not isinstance(payload.get("events"), list):
+        raise RuntimeError("public/events.json must be an object with an events array")
+    return payload
+
+
+def _parse_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _validate_page(limit: int, offset: int) -> None:
+    if not 1 <= limit <= MAX_LIMIT:
+        raise ValueError(f"limit must be between 1 and {MAX_LIMIT}")
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
+
+
+def _series_id(row: dict[str, Any]) -> str | None:
+    for key in ("ontology_id", "series_id", "canonical_series_id", "event_series_id"):
+        value = row.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def event_provenance(row: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    generated = payload.get("generated_at")
+    generated_dt = _parse_time(generated)
+    freshness_seconds = None
+    if generated_dt is not None:
+        freshness_seconds = max(0, int((datetime.now(UTC) - generated_dt.astimezone(UTC)).total_seconds()))
+
+    tracked = {
+        "source_created_at": row.get("source_created_at"),
+        "first_seen_at": row.get("first_seen_at"),
+        "last_seen_at": row.get("last_seen_at"),
+        "ontology_id": _series_id(row),
+    }
+    null_reasons = {
+        key: "not_recorded_in_public_event"
+        for key, value in tracked.items()
+        if value is None
+    }
+    return {
+        "canonical_id": row.get("id"),
+        "schema_version": payload.get("schema_version"),
+        "event_start": row.get("starts_at"),
+        "source_created_at": tracked["source_created_at"],
+        "first_seen_at": tracked["first_seen_at"],
+        "last_seen_at": tracked["last_seen_at"],
+        "generated_at": generated,
+        "source_type": row.get("source"),
+        "source_id": row.get("source_id"),
+        "source_url": row.get("url"),
+        "classification_rule": row.get("category_source"),
+        "classification_reason": row.get("category_evidence") or [],
+        "ontology_id": tracked["ontology_id"],
+        "freshness_seconds": freshness_seconds,
+        "null_reasons": null_reasons,
+    }
+
+
+def with_provenance(row: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    return {**row, "provenance": event_provenance(row, payload)}
+
+
+def search_events(
+    query: str | None = None,
+    category: str | None = None,
+    series_id: str | None = None,
+    start_at: str | None = None,
+    end_at: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    _validate_page(limit, offset)
+    payload = _events_payload()
+    rows = [row for row in payload["events"] if isinstance(row, dict)]
+
+    if query:
+        needle = query.casefold().strip()
+        rows = [
+            row
+            for row in rows
+            if needle
+            in " ".join(
+                str(row.get(key) or "")
+                for key in ("title", "description", "organizer", "location", "source_id")
+            ).casefold()
+        ]
+    if category:
+        rows = [row for row in rows if row.get("category") == category]
+    if series_id:
+        rows = [row for row in rows if _series_id(row) == series_id]
+
+    start_dt = _parse_time(start_at)
+    end_dt = _parse_time(end_at)
+    if start_at and start_dt is None:
+        raise ValueError("start_at must be ISO-8601")
+    if end_at and end_dt is None:
+        raise ValueError("end_at must be ISO-8601")
+    if start_dt is not None:
+        rows = [row for row in rows if (dt := _parse_time(row.get("starts_at"))) is not None and dt >= start_dt]
+    if end_dt is not None:
+        rows = [row for row in rows if (dt := _parse_time(row.get("starts_at"))) is not None and dt < end_dt]
+
+    total = len(rows)
+    page = rows[offset : offset + limit]
+    return {
+        "schema_version": "cast-event.mcp-read-model.v1",
+        "source_schema_version": payload.get("schema_version"),
+        "generated_at": payload.get("generated_at"),
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "items": [with_provenance(row, payload) for row in page],
+    }
+
+
+def get_event(event_id: str) -> dict[str, Any] | None:
+    payload = _events_payload()
+    row = next((row for row in payload["events"] if isinstance(row, dict) and row.get("id") == event_id), None)
+    return with_provenance(row, payload) if row is not None else None
+
+
+def tonight_events(date_jst: str | None = None, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+    _validate_page(limit, offset)
+    if date_jst:
+        try:
+            target = date.fromisoformat(date_jst)
+        except ValueError as exc:
+            raise ValueError("date_jst must be YYYY-MM-DD") from exc
+    else:
+        target = datetime.now(JST).date()
+
+    payload = _events_payload()
+    rows = []
+    for row in payload["events"]:
+        if not isinstance(row, dict):
+            continue
+        starts = _parse_time(row.get("starts_at"))
+        if starts is not None and starts.astimezone(JST).date() == target:
+            rows.append(row)
+    rows.sort(key=lambda row: row.get("starts_at") or "")
+    total = len(rows)
+    return {
+        "schema_version": "cast-event.mcp-read-model.v1",
+        "date_jst": target.isoformat(),
+        "generated_at": payload.get("generated_at"),
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "items": [with_provenance(row, payload) for row in rows[offset : offset + limit]],
+    }
+
+
+def get_series(series_id: str) -> dict[str, Any] | None:
+    ontology = _load_json("event-ontology.json")
+    entries = ontology.get("entries", []) if isinstance(ontology, dict) else []
+    return next(
+        (entry for entry in entries if isinstance(entry, dict) and entry.get("canonical_id") == series_id),
+        None,
+    )
+
+
+def source_health() -> dict[str, Any]:
+    return _load_json("health.json")
+
+
+def classification_audit() -> dict[str, Any]:
+    yahoo = _load_json("yahoo-classifier-audit.json")
+    ontology = _load_json("ontology-match-audit.json")
+    return {
+        "schema_version": "cast-event.classification-audit-view.v1",
+        "generated_at": yahoo.get("generated_at") if isinstance(yahoo, dict) else None,
+        "yahoo_classifier": yahoo,
+        "ontology_match": ontology,
+    }
+
+
+def ontology() -> dict[str, Any]:
+    return _load_json("event-ontology.json")
+
+
+def data_quality() -> dict[str, Any]:
+    payload = _events_payload()
+    rows = [row for row in payload["events"] if isinstance(row, dict)]
+    health = source_health()
+    ontology_payload = ontology()
+    ids = [row.get("id") for row in rows]
+    duplicate_ids = len(ids) - len(set(ids))
+    ambiguous = ontology_payload.get("matching_policy", {}).get("ambiguous_match_action")
+    artifacts = {}
+    for name in (
+        "events.json",
+        "health.json",
+        "event-ontology.json",
+        "ontology-match-audit.json",
+        "category-ontology.json",
+        "yahoo-classifier-audit.json",
+    ):
+        path = PUBLIC / name
+        raw = path.read_bytes()
+        artifacts[name] = {"bytes": len(raw), "sha256": hashlib.sha256(raw).hexdigest()}
+    return {
+        "schema_version": "cast-event.data-quality.v1",
+        "generated_at": payload.get("generated_at"),
+        "event_count": len(rows),
+        "health_event_count": health.get("event_count"),
+        "event_count_matches_health": health.get("event_count") == len(rows),
+        "duplicate_event_ids": duplicate_ids,
+        "ontology_ambiguous_events": health.get("ontology", {}).get("ambiguous_events"),
+        "ambiguous_match_action": ambiguous,
+        "low_confidence_event_count": health.get("category_classification", {}).get("low_confidence_event_count"),
+        "edinetdb_mode": "not_applicable",
+        "canonical_repository": "KAFKA2306/cast_event_cal",
+        "artifacts": artifacts,
+    }
+
+
+def methodology() -> dict[str, Any]:
+    ontology_payload = ontology()
+    health = source_health()
+    return {
+        "schema_version": "cast-event.methodology.v1",
+        "canonical_repository": "KAFKA2306/cast_event_cal",
+        "deploy_repository": "KAFKA2306/vrc_cast_event_calender",
+        "classification": "deterministic_fail_close",
+        "llm_as_canonical_classifier": False,
+        "ontology_governance": ontology_payload.get("governance"),
+        "matching_policy": ontology_payload.get("matching_policy"),
+        "category_classification": health.get("category_classification"),
+        "time_semantics": {
+            "event_start": "starts_at",
+            "source_observed": "fetched_at/source-specific observed fields when present",
+            "snapshot_generated": "events.json generated_at",
+            "timezone_for_tonight": "Asia/Tokyo",
+        },
+        "edinetdb_mode": "not_applicable",
+    }

--- a/cast_event_cal/mcp_server.py
+++ b/cast_event_cal/mcp_server.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server import MCPServer
+
+from . import mcp_read_model as read_model
+
+MCP_SCHEMA_VERSION = "cast-event.mcp.v1"
+
+mcp = MCPServer(
+    "cast_event_cal",
+    version="2.0.0",
+    instructions=(
+        "Read-only access to the canonical VRChat event snapshot. "
+        "Preserve source timestamps, classification evidence and ontology ambiguity; "
+        "do not infer missing event facts."
+    ),
+)
+
+
+@mcp.tool()
+def search_events(
+    query: str | None = None,
+    category: str | None = None,
+    series_id: str | None = None,
+    start_at: str | None = None,
+    end_at: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Search canonical events with deterministic filters and bounded pagination."""
+    return read_model.search_events(
+        query=query,
+        category=category,
+        series_id=series_id,
+        start_at=start_at,
+        end_at=end_at,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@mcp.tool()
+def get_event(event_id: str) -> dict[str, Any]:
+    """Get one event by canonical ID with source and classification provenance."""
+    item = read_model.get_event(event_id)
+    return {
+        "schema_version": MCP_SCHEMA_VERSION,
+        "found": item is not None,
+        "event": item,
+    }
+
+
+@mcp.tool()
+def get_tonight_events(
+    date_jst: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List events whose starts_at falls on a JST calendar date; pass date_jst for replay."""
+    return read_model.tonight_events(date_jst=date_jst, limit=limit, offset=offset)
+
+
+@mcp.tool()
+def get_series(series_id: str) -> dict[str, Any]:
+    """Get one human-curated event-series ontology entry by canonical_id."""
+    item = read_model.get_series(series_id)
+    return {
+        "schema_version": MCP_SCHEMA_VERSION,
+        "found": item is not None,
+        "series": item,
+    }
+
+
+@mcp.tool()
+def get_source_health() -> dict[str, Any]:
+    """Return canonical source success/failure counts and snapshot health."""
+    return read_model.source_health()
+
+
+@mcp.tool()
+def get_classification_audit() -> dict[str, Any]:
+    """Return deterministic Yahoo classifier and ontology-match audit artifacts."""
+    return read_model.classification_audit()
+
+
+@mcp.tool()
+def get_ontology() -> dict[str, Any]:
+    """Return the human-curated series ontology and fail-close matching policy."""
+    return read_model.ontology()
+
+
+@mcp.tool()
+def get_data_quality() -> dict[str, Any]:
+    """Return count parity, duplicate-ID, ambiguity and public-artifact hash checks."""
+    return read_model.data_quality()
+
+
+@mcp.tool()
+def get_methodology() -> dict[str, Any]:
+    """Return canonical/deploy boundaries, time semantics and deterministic classification policy."""
+    return read_model.methodology()
+
+
+def main() -> None:
+    """Run the canonical Event MCP server on localhost."""
+    mcp.run("streamable-http", host="127.0.0.1", port=8011)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,61 @@
+# Event MCP
+
+`cast_event_cal` はVRChatイベントデータの正本です。MCPは `public/*.json` に対するread-only adapterであり、取得・分類・ontology matchingを再実装しません。
+
+## Start
+
+```bash
+python -m pip install -e '.[mcp]'
+cast-event-cal-mcp
+```
+
+既定は `127.0.0.1:8011` のStreamable HTTPです。
+
+## Tools
+
+- `search_events`
+- `get_event`
+- `get_tonight_events`
+- `get_series`
+- `get_source_health`
+- `get_classification_audit`
+- `get_ontology`
+- `get_data_quality`
+- `get_methodology`
+
+検索系は `limit <= 100` と `offset` を要求し、大量candidate historyを無制限に返しません。
+
+## Provenance
+
+イベントtoolは、公開event recordを変更せず `provenance` を追加します。存在する範囲で以下を返します。
+
+- canonical ID
+- public schema version
+- event start
+- source-created / first-seen / last-seen timestamps
+- snapshot generated timestamp
+- source type / source ID / source URL
+- classification rule / classification evidence
+- ontology/series ID
+- freshness seconds
+- missing fieldの `null_reasons`
+
+公開eventに記録されていない観測時刻やseries IDを推測生成しません。
+
+## Tonight replay
+
+`get_tonight_events(date_jst='YYYY-MM-DD')` は `starts_at` をAsia/Tokyoへ変換し、指定JST暦日だけを返します。明示日を渡せるため、相対的な「今夜」を後日再現できます。
+
+## Fail-close
+
+- event ID重複はdata-quality contract違反
+- `health.json:event_count` と `events.json` 件数不一致はcontract違反
+- ontology ambiguous countは0を要求
+- ontology matching policyは `ambiguous_match_action=reject`
+- LLMはcanonical classifierにしない
+- deploy repo `KAFKA2306/vrc_cast_event_calender` へ分類ロジックを複製しない
+- EDINET DBは使用しない (`edinetdb_mode=not_applicable`)
+
+## Tests
+
+`tests/test_mcp_contract.py` はMCP tool discovery、public events parity、event provenance、JST replay、human-curated ontology、duplicate/ambiguity gate、canonical/deploy boundaryを検証します。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8,<10", "ruff>=0.12,<1"]
+dev = ["pytest>=8,<10", "ruff>=0.12,<1", "mcp>=2,<3"]
 mcp = ["mcp>=2,<3"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=8,<10", "ruff>=0.12,<1"]
+mcp = ["mcp>=2,<3"]
 
 [project.scripts]
 cast-event-cal = "cast_event_cal.core:main"
+cast-event-cal-mcp = "cast_event_cal.mcp_server:main"
 
 [tool.setuptools.packages.find]
 include = ["cast_event_cal*"]

--- a/tests/test_mcp_contract.py
+++ b/tests/test_mcp_contract.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from cast_event_cal import mcp_read_model, mcp_server
+
+ROOT = Path(__file__).resolve().parents[1]
+JST = ZoneInfo("Asia/Tokyo")
+
+
+def events_payload() -> dict:
+    return json.loads((ROOT / "public" / "events.json").read_text(encoding="utf-8"))
+
+
+def test_mcp_tool_catalog_is_discoverable() -> None:
+    tools = asyncio.run(mcp_server.mcp.list_tools())
+    assert {tool.name for tool in tools} == {
+        "search_events",
+        "get_event",
+        "get_tonight_events",
+        "get_series",
+        "get_source_health",
+        "get_classification_audit",
+        "get_ontology",
+        "get_data_quality",
+        "get_methodology",
+    }
+
+
+def test_public_events_and_mcp_search_are_same_records() -> None:
+    payload = events_payload()
+    first = payload["events"][0]
+    page = mcp_read_model.search_events(limit=1)
+    assert page["total"] == payload["count"] == len(payload["events"])
+    projected = dict(page["items"][0])
+    provenance = projected.pop("provenance")
+    assert projected == first
+    assert provenance["canonical_id"] == first["id"]
+    assert provenance["schema_version"] == payload["schema_version"]
+    assert provenance["event_start"] == first.get("starts_at")
+    assert provenance["source_id"] == first.get("source_id")
+    assert provenance["source_url"] == first.get("url")
+    assert provenance["classification_rule"] == first.get("category_source")
+    assert provenance["classification_reason"] == (first.get("category_evidence") or [])
+
+
+def test_get_event_preserves_canonical_record() -> None:
+    payload = events_payload()
+    first = payload["events"][0]
+    item = mcp_read_model.get_event(first["id"])
+    assert item is not None
+    projected = dict(item)
+    projected.pop("provenance")
+    assert projected == first
+
+
+def test_tonight_replay_uses_explicit_jst_calendar_date() -> None:
+    payload = events_payload()
+    first_with_time = next(row for row in payload["events"] if row.get("starts_at"))
+    starts = datetime.fromisoformat(first_with_time["starts_at"].replace("Z", "+00:00"))
+    target = starts.astimezone(JST).date().isoformat()
+    result = mcp_read_model.tonight_events(date_jst=target, limit=100)
+    assert result["date_jst"] == target
+    assert all(
+        datetime.fromisoformat(item["starts_at"].replace("Z", "+00:00")).astimezone(JST).date().isoformat() == target
+        for item in result["items"]
+    )
+
+
+def test_series_is_human_curated_and_round_trips() -> None:
+    ontology = mcp_read_model.ontology()
+    first = ontology["entries"][0]
+    assert mcp_read_model.get_series(first["canonical_id"]) == first
+    assert ontology["governance"]["curation_mode"] == "human_only"
+    assert ontology["matching_policy"]["ambiguous_match_action"] == "reject"
+
+
+def test_data_quality_fails_closed_on_duplicates_and_ambiguity() -> None:
+    quality = mcp_read_model.data_quality()
+    assert quality["event_count_matches_health"] is True
+    assert quality["duplicate_event_ids"] == 0
+    assert quality["ontology_ambiguous_events"] == 0
+    assert quality["ambiguous_match_action"] == "reject"
+    assert quality["edinetdb_mode"] == "not_applicable"
+    assert quality["canonical_repository"] == "KAFKA2306/cast_event_cal"
+    assert all(len(item["sha256"]) == 64 for item in quality["artifacts"].values())
+
+
+def test_methodology_keeps_deploy_repo_projection_only() -> None:
+    methodology = mcp_read_model.methodology()
+    assert methodology["canonical_repository"] == "KAFKA2306/cast_event_cal"
+    assert methodology["deploy_repository"] == "KAFKA2306/vrc_cast_event_calender"
+    assert methodology["llm_as_canonical_classifier"] is False
+    assert methodology["classification"] == "deterministic_fail_close"
+    assert methodology["time_semantics"]["timezone_for_tonight"] == "Asia/Tokyo"


### PR DESCRIPTION
## Summary

Implements the executable Event MCP slice of #47 while keeping `cast_event_cal` as the only canonical ingestion/classification repository.

### MCP tools
- `search_events`
- `get_event`
- `get_tonight_events`
- `get_series`
- `get_source_health`
- `get_classification_audit`
- `get_ontology`
- `get_data_quality`
- `get_methodology`

### Contract
- MCP reads existing `public/*.json`; it does not duplicate ingestion or classifier logic.
- Search is bounded to 100 records per call with `limit`/`offset`.
- `get_tonight_events(date_jst=...)` allows deterministic JST replay.
- Event results preserve the canonical record and add source/classification provenance plus explicit null reasons for fields not recorded in the public event.
- Ontology remains `human_only` with ambiguous matches rejected.
- data-quality checks count parity, duplicate IDs, ambiguity and SHA-256 for canonical public artifacts.
- `KAFKA2306/vrc_cast_event_calender` remains deploy/projection only.
- `edinetdb_mode=not_applicable`; this feature consumes no EDINET DB quota.

### SDK
Adds MCP Python SDK v2 as an optional/runtime-development extra and a `cast-event-cal-mcp` entrypoint.

### Validation
`tests/test_mcp_contract.py` verifies MCP tool discovery, public/events parity, provenance, JST date replay, series ontology round-trip, fail-close quality gates, and canonical/deploy boundaries. Existing CI runs these tests across Python 3.11/3.12/3.13.

Related: #47
Deploy projection manifest: KAFKA2306/vrc_cast_event_calender#31
Central EDINET DB policy: KAFKA2306/semiconductor-earnings-model#78