### PR TITLE
Adopt central residue-free branch GC

### DIFF
--- a/.github/workflows/merged-branch-gc.yml
+++ b/.github/workflows/merged-branch-gc.yml
@@ -1,0 +1,33 @@
+name: Residue-free merged branch GC
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/merged-branch-gc.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/merged-branch-gc.yml"
+  schedule:
+    - cron: "35 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: KAFKA2306/semiconductor-earnings-model/.github/workflows/reusable-merged-branch-gc.yml@542bbe6b6c15c325dfa5100c9824aeb3008d586e
+    with:
+      apply: false
+
+  cleanup:
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: write
+      pull-requests: read
+    uses: KAFKA2306/semiconductor-earnings-model/.github/workflows/reusable-merged-branch-gc.yml@542bbe6b6c15c325dfa5100c9824aeb3008d586e
+    with:
+      apply: true


### PR DESCRIPTION
## Contract

Adopt the SHA-pinned central merge/ancestry branch cleanup without duplicating implementation.

PR runs are read-only dry-runs. Main/scheduled runs receive write permission only for proven-safe deletions. Open PR, protected, diverged and unproven branches remain untouched.

The previously merged Event MCP/provenance branch is eligible only with exact merge/ancestry proof.