### PR TITLE
Remove delivery-owned Cloudflare routing from canonical public

### DIFF
--- a/docs/canonical-flow.md
+++ b/docs/canonical-flow.md
@@ -20,6 +20,8 @@ source observations
 - Acceptance/rejection decisions are produced by deterministic classifiers and recorded with reasons.
 - Event identity and ontology ownership live in this repository.
 - `public/` is a materialized projection from canonical state, not an independent source of truth.
+- Canonical UI materialization such as `public/index.html` remains here because it is generated from canonical state by the canonical renderer.
+- Delivery-platform runtime configuration is not canonical event state. Cloudflare Pages routing such as `_routes.json` is owned by `KAFKA2306/vrc_cast_event_calender` and must not be materialized under this repository's `public/` tree.
 - `vrc_cast_event_calender` may validate and distribute these outputs, but must not own a second collector, classifier, ontology, or event-state machine.
 
 ## Repository KPIs
@@ -41,4 +43,4 @@ Unknown or uninstrumented values are not converted to zero.
 
 ## CI contract
 
-CI must fail if the canonical ownership statement disappears, the KPI set expands beyond the three names above, or the obsolete weekly research workflow is reintroduced. Existing event, ontology, provenance, MCP, and publication tests remain the authoritative functional gates.
+CI must fail if the canonical ownership statement disappears, the KPI set expands beyond the three names above, an obsolete noncanonical workflow is reintroduced, or delivery-owned Cloudflare routing returns under `public/`. Existing event, ontology, provenance, MCP, and publication tests remain the authoritative functional gates.

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,5 +1,0 @@
-{
-  "version": 1,
-  "include": ["/"],
-  "exclude": []
-}

--- a/tests/test_pages_quality_view.py
+++ b/tests/test_pages_quality_view.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 
@@ -7,11 +6,6 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_cloudflare_worker_is_projection_owned() -> None:
     assert not (ROOT / "functions").exists()
-
-
-def test_function_invocation_is_limited_to_root() -> None:
-    routes = json.loads((ROOT / "public" / "_routes.json").read_text(encoding="utf-8"))
-    assert routes == {"version": 1, "include": ["/"], "exclude": []}
 
 
 def test_quality_view_has_accessibility_mobile_and_density_contracts() -> None:

--- a/tests/test_repository_ratchet.py
+++ b/tests/test_repository_ratchet.py
@@ -33,3 +33,9 @@ def test_obsolete_noncanonical_workflows_are_absent() -> None:
     workflow_dir = ROOT / ".github" / "workflows"
     present = sorted(name for name in obsolete if (workflow_dir / name).exists())
     assert present == []
+
+
+def test_delivery_owned_cloudflare_routes_are_absent() -> None:
+    assert not (ROOT / "public" / "_routes.json").exists()
+    text = DOC.read_text(encoding="utf-8")
+    assert "Cloudflare Pages routing such as `_routes.json` is owned by `KAFKA2306/vrc_cast_event_calender`" in text


### PR DESCRIPTION
Continues #51 by separating delivery-platform runtime configuration from canonical event/UI materialization.

- remove `public/_routes.json` from the canonical snapshot
- document that canonical `public/index.html` remains canonical renderer output, while Cloudflare Pages routing is projection/delivery-owned
- add a ratchet test preventing `_routes.json` from returning under canonical `public/`

The delivery repository was prepared first in KAFKA2306/vrc_cast_event_calender#42 so its deploy workflow preserves the root delivery-owned `_routes.json` when replacing canonical snapshot assets.