### PR TITLE
Fail-safe unreachable public event images before render

### DIFF
--- a/scripts/enrich_vrchat_group_assets.py
+++ b/scripts/enrich_vrchat_group_assets.py
@@ -11,6 +11,8 @@ from urllib.parse import urlparse
 
 import httpx
 
+from scripts.validate_public_image_assets import sanitize_event_images, write_audit
+
 EVENTS = Path("public/events.json")
 AUDIT = Path("public/vrchat-group-asset-audit.json")
 GROUP_RE = re.compile(r"^https://(?:www\.)?vrchat\.com/home/group/(grp_[A-Za-z0-9-]+)(?:[/?#].*)?$", re.I)
@@ -88,17 +90,25 @@ def main() -> int:
             row["preferred_image_kind"] = row.get("image_kind")
         enriched.append(row)
 
+    enriched, image_audit = sanitize_event_images(enriched)
+    write_audit(image_audit)
     document["events"] = enriched
     document["vrchat_group_assets_enriched_at"] = now_iso()
+    document["image_reachability_validated_at"] = image_audit["generated_at"]
     EVENTS.write_text(json.dumps(document, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     audit = {
         "schema_version": "1.0",
         "generated_at": now_iso(),
         "group_url_count": len(urls),
-        "group_image_count": sum(bool(value) for value in images.values()),
+        "group_image_count": sum(bool(row.get("vrchat_group_image_url")) for row in enriched),
         "events_with_group_url": sum(bool(row.get("vrchat_group_url")) for row in enriched),
         "events_with_group_image": sum(bool(row.get("vrchat_group_image_url")) for row in enriched),
         "failures": dict(failures),
+        "image_reachability": {
+            "checked_url_count": image_audit["checked_url_count"],
+            "failed_url_count": image_audit["failed_url_count"],
+            "events_degraded": image_audit["events_degraded"],
+        },
         "sample": [
             {
                 "id": row.get("id"),
@@ -111,7 +121,16 @@ def main() -> int:
         ][:25],
     }
     AUDIT.write_text(json.dumps(audit, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    print(json.dumps({key: audit[key] for key in ("group_url_count", "group_image_count", "events_with_group_url", "events_with_group_image")}, ensure_ascii=False))
+    print(
+        json.dumps(
+            {
+                key: audit[key]
+                for key in ("group_url_count", "group_image_count", "events_with_group_url", "events_with_group_image")
+            }
+            | {"image_reachability": audit["image_reachability"]},
+            ensure_ascii=False,
+        )
+    )
     return 0
 
 

--- a/scripts/validate_public_image_assets.py
+++ b/scripts/validate_public_image_assets.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+import httpx
+
+AUDIT_PATH = Path("public/image-reachability-audit.json")
+IMAGE_FIELDS = (
+    ("preferred_image_url", "preferred_image_kind"),
+    ("vrchat_group_image_url", None),
+    ("image_url", "image_kind"),
+)
+
+
+def now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def probe_image(url: str) -> tuple[bool, str]:
+    try:
+        with httpx.Client(
+            timeout=8,
+            follow_redirects=True,
+            headers={"User-Agent": "Mozilla/5.0 cast-event-cal/2", "Range": "bytes=0-0"},
+        ) as client:
+            with client.stream("GET", url) as response:
+                response.raise_for_status()
+                content_type = response.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+                if not content_type.startswith("image/"):
+                    return False, f"unexpected_content_type:{content_type or 'missing'}"
+                return True, "ok"
+    except httpx.HTTPStatusError as exc:
+        return False, f"http_{exc.response.status_code}"
+    except httpx.HTTPError as exc:
+        return False, type(exc).__name__
+
+
+def sanitize_event_images(
+    events: list[dict[str, Any]],
+    *,
+    probe: Callable[[str], tuple[bool, str]] = probe_image,
+    max_workers: int = 12,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    urls = sorted(
+        {
+            value
+            for event in events
+            for field, _kind_field in IMAGE_FIELDS
+            if (value := str(event.get(field) or "")).startswith("https://")
+        }
+    )
+    results: dict[str, tuple[bool, str]] = {}
+    with ThreadPoolExecutor(max_workers=max(1, min(max_workers, len(urls) or 1))) as executor:
+        futures = {executor.submit(probe, url): url for url in urls}
+        for future in as_completed(futures):
+            url = futures[future]
+            try:
+                results[url] = future.result()
+            except Exception as exc:  # fail closed for an optional visual asset
+                results[url] = (False, type(exc).__name__)
+
+    failures: Counter[str] = Counter()
+    failed_urls: list[dict[str, str]] = []
+    for url, (ok, reason) in results.items():
+        if not ok:
+            failures[reason] += 1
+            failed_urls.append({"url": url, "reason": reason})
+
+    sanitized: list[dict[str, Any]] = []
+    stripped_fields = 0
+    events_degraded = 0
+    for event in events:
+        row = dict(event)
+        degraded = False
+        for field, kind_field in IMAGE_FIELDS:
+            url = str(row.get(field) or "")
+            if url.startswith("https://") and not results.get(url, (False, "not_checked"))[0]:
+                row[field] = None
+                if kind_field:
+                    row[kind_field] = None
+                stripped_fields += 1
+                degraded = True
+        if degraded:
+            events_degraded += 1
+        sanitized.append(row)
+
+    audit = {
+        "schema_version": "1.0",
+        "generated_at": now_iso(),
+        "policy": "fail-closed-for-unreachable-optional-image-assets",
+        "checked_url_count": len(urls),
+        "reachable_url_count": sum(ok for ok, _reason in results.values()),
+        "failed_url_count": len(failed_urls),
+        "events_degraded": events_degraded,
+        "stripped_image_fields": stripped_fields,
+        "failures": dict(sorted(failures.items())),
+        "failed_urls": failed_urls,
+    }
+    return sanitized, audit
+
+
+def write_audit(audit: dict[str, Any], path: Path = AUDIT_PATH) -> None:
+    path.write_text(json.dumps(audit, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")

--- a/tests/test_public_image_reachability.py
+++ b/tests/test_public_image_reachability.py
@@ -1,0 +1,61 @@
+from scripts.validate_public_image_assets import sanitize_event_images
+
+
+def test_unreachable_preferred_image_falls_back_without_removing_valid_source_image() -> None:
+    events = [
+        {
+            "id": "evt-1",
+            "preferred_image_url": "https://cdn.example/broken.webp",
+            "preferred_image_kind": "vrchat_group",
+            "image_url": "https://cdn.example/source.webp",
+            "image_kind": "post_media",
+        }
+    ]
+
+    def probe(url: str) -> tuple[bool, str]:
+        if "broken" in url:
+            return False, "http_404"
+        return True, "ok"
+
+    sanitized, audit = sanitize_event_images(events, probe=probe, max_workers=2)
+    assert sanitized[0]["preferred_image_url"] is None
+    assert sanitized[0]["preferred_image_kind"] is None
+    assert sanitized[0]["image_url"] == "https://cdn.example/source.webp"
+    assert sanitized[0]["image_kind"] == "post_media"
+    assert audit["failed_url_count"] == 1
+    assert audit["events_degraded"] == 1
+    assert audit["failures"] == {"http_404": 1}
+
+
+def test_duplicate_image_url_is_probed_once_and_stripped_from_all_render_fields() -> None:
+    calls: list[str] = []
+    events = [
+        {
+            "id": "evt-2",
+            "preferred_image_url": "https://cdn.example/stale.webp",
+            "preferred_image_kind": "organizer_profile",
+            "image_url": "https://cdn.example/stale.webp",
+            "image_kind": "organizer_profile",
+        }
+    ]
+
+    def probe(url: str) -> tuple[bool, str]:
+        calls.append(url)
+        return False, "http_404"
+
+    sanitized, audit = sanitize_event_images(events, probe=probe)
+    assert calls == ["https://cdn.example/stale.webp"]
+    assert sanitized[0]["preferred_image_url"] is None
+    assert sanitized[0]["preferred_image_kind"] is None
+    assert sanitized[0]["image_url"] is None
+    assert sanitized[0]["image_kind"] is None
+    assert audit["checked_url_count"] == 1
+    assert audit["stripped_image_fields"] == 2
+
+
+def test_reachable_image_is_preserved() -> None:
+    events = [{"id": "evt-3", "image_url": "https://cdn.example/live.webp", "image_kind": "post_media"}]
+    sanitized, audit = sanitize_event_images(events, probe=lambda _url: (True, "ok"))
+    assert sanitized == events
+    assert audit["reachable_url_count"] == 1
+    assert audit["failed_url_count"] == 0


### PR DESCRIPTION
## Decision
Can a canonical snapshot be published without shipping externally broken event images that cause browser/Lighthouse errors?

## Before
`enrich_official_assets.py` accepted image metadata from X syndication, and a freshly fetched `pbs.twimg.com` profile URL could still return 404. The downstream projection `workflow_run` Web quality gate caught this as a Lighthouse `errors-in-console` failure.

## After
- add a reusable reachability validator for the actual rendered image fields
- de-duplicate network probes and require successful `image/*` responses
- fail safe by removing only unreachable optional image fields, preserving event/link data and valid fallback images
- emit `public/image-reachability-audit.json`
- run the validator automatically after VRChat-group image enrichment and before frontend rendering
- add regression tests for 404 fallback, duplicate URL probing, and reachable preservation

This keeps the browser quality gate strict rather than suppressing console errors.

Tracks the canonical ownership/complexity ratchet in #51.