### PR TITLE
Fix production script import contract for image validation

### DIFF
--- a/scripts/enrich_vrchat_group_assets.py
+++ b/scripts/enrich_vrchat_group_assets.py
@@ -11,7 +11,12 @@ from urllib.parse import urlparse
 
 import httpx
 
-from scripts.validate_public_image_assets import sanitize_event_images, write_audit
+try:
+    from scripts.validate_public_image_assets import sanitize_event_images, write_audit
+except ModuleNotFoundError as exc:
+    if exc.name != "scripts":
+        raise
+    from validate_public_image_assets import sanitize_event_images, write_audit
 
 EVENTS = Path("public/events.json")
 AUDIT = Path("public/vrchat-group-asset-audit.json")

--- a/tests/test_vrchat_group_assets.py
+++ b/tests/test_vrchat_group_assets.py
@@ -1,4 +1,13 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
 from scripts.enrich_vrchat_group_assets import extract_group_image, group_url
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "enrich_vrchat_group_assets.py"
 
 
 def test_extract_group_image_from_open_graph_metadata() -> None:
@@ -22,3 +31,23 @@ def test_group_url_prefers_official_vrchat_group_link() -> None:
         ],
     }
     assert group_url(event) == "https://vrchat.com/home/group/grp_db9d6929-5d48-4047-8aea-36d560bcec26"
+
+
+def test_direct_script_execution_matches_production_entrypoint(tmp_path: Path) -> None:
+    public = tmp_path / "public"
+    public.mkdir()
+    (public / "events.json").write_text(json.dumps({"events": []}) + "\n", encoding="utf-8")
+
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    audit = json.loads((public / "image-reachability-audit.json").read_text(encoding="utf-8"))
+    assert audit["checked_url_count"] == 0
+    groups = json.loads((public / "vrchat-group-asset-audit.json").read_text(encoding="utf-8"))
+    assert groups["image_reachability"]["checked_url_count"] == 0


### PR DESCRIPTION
## Decision
Make the production `python scripts/enrich_vrchat_group_assets.py` entrypoint reliably execute the reusable image reachability validator instead of failing before validation.

## Change
- fall back to sibling-module import only when direct script execution cannot resolve the `scripts` package
- add a subprocess regression test that invokes the exact production entrypoint from an isolated working directory and verifies audit generation

## Evidence
Production run 31867775206 failed at `Enrich official VRChat group images` with `ModuleNotFoundError: No module named 'scripts'` while unit/CI imports had succeeded. The new test closes that execution-shape gap.