### PR TITLE
feat: log cumulative accepted-event KPI on every refresh

### DIFF
--- a/scripts/build_registration_count_audit.py
+++ b/scripts/build_registration_count_audit.py
@@ -8,6 +8,7 @@ from typing import Any
 CALENDAR_HEALTH = Path("public/health.json")
 YAHOO_HEALTH = Path("data/yahoo_realtime_health.json")
 OUTPUT = Path("public/registration-count-audit.json")
+KPI_LOG = Path("public/accepted-event-kpi.jsonl")
 MAX_SNAPSHOTS = 90
 
 
@@ -87,10 +88,52 @@ def build() -> dict[str, Any]:
     }
 
 
+def read_kpi_log(path: Path = KPI_LOG) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not raw.strip():
+            continue
+        row = json.loads(raw)
+        if not isinstance(row, dict):
+            raise ValueError(f"KPI log line {line_number} must be an object")
+        rows.append(row)
+    return rows
+
+
+def append_kpi_log(latest: dict[str, Any], path: Path = KPI_LOG) -> dict[str, Any]:
+    generated_at = str(latest["generated_at"])
+    accepted = integer(latest["yahoo_accepted_count"])
+    rows = read_kpi_log(path)
+
+    if rows and rows[-1].get("generated_at") == generated_at:
+        return rows[-1]
+
+    previous = rows[-1] if rows else None
+    previous_accepted = integer(previous["accepted_event_cumulative"]) if previous else None
+    if previous_accepted is not None and accepted < previous_accepted:
+        raise ValueError(
+            "accepted-event cumulative KPI must not decrease: "
+            f"{previous_accepted} -> {accepted}"
+        )
+
+    row = {
+        "generated_at": generated_at,
+        "accepted_event_cumulative": accepted,
+        "delta": None if previous_accepted is None else accepted - previous_accepted,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+    return row
+
+
 def main() -> int:
     payload = build()
     OUTPUT.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    print(json.dumps(payload["latest"], ensure_ascii=False))
+    kpi = append_kpi_log(payload["latest"])
+    print(json.dumps({"latest": payload["latest"], "kpi": kpi}, ensure_ascii=False))
     return 0
 
 

--- a/tests/test_registration_count_audit.py
+++ b/tests/test_registration_count_audit.py
@@ -70,6 +70,61 @@ def test_build_appends_snapshot_and_computes_deltas(tmp_path, monkeypatch):
     assert latest["delta_from_previous"]["source_counts"]["yahoo_realtime_events"] == 4
 
 
+def test_append_kpi_log_keeps_only_cumulative_accepted_event_kpi(tmp_path):
+    path = tmp_path / "accepted-event-kpi.jsonl"
+
+    first = audit.append_kpi_log(
+        {"generated_at": "2026-08-15T00:00:00Z", "yahoo_accepted_count": 701},
+        path,
+    )
+    second = audit.append_kpi_log(
+        {"generated_at": "2026-08-16T00:00:00Z", "yahoo_accepted_count": 708},
+        path,
+    )
+
+    assert first == {
+        "generated_at": "2026-08-15T00:00:00Z",
+        "accepted_event_cumulative": 701,
+        "delta": None,
+    }
+    assert second == {
+        "generated_at": "2026-08-16T00:00:00Z",
+        "accepted_event_cumulative": 708,
+        "delta": 7,
+    }
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert rows == [first, second]
+    assert set(rows[-1]) == {"generated_at", "accepted_event_cumulative", "delta"}
+
+
+def test_append_kpi_log_is_idempotent_for_same_snapshot(tmp_path):
+    path = tmp_path / "accepted-event-kpi.jsonl"
+    latest = {"generated_at": "2026-08-15T00:00:00Z", "yahoo_accepted_count": 701}
+
+    audit.append_kpi_log(latest, path)
+    audit.append_kpi_log(latest, path)
+
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_append_kpi_log_rejects_cumulative_decrease(tmp_path):
+    path = tmp_path / "accepted-event-kpi.jsonl"
+    audit.append_kpi_log(
+        {"generated_at": "2026-08-15T00:00:00Z", "yahoo_accepted_count": 701},
+        path,
+    )
+
+    try:
+        audit.append_kpi_log(
+            {"generated_at": "2026-08-16T00:00:00Z", "yahoo_accepted_count": 700},
+            path,
+        )
+    except ValueError as exc:
+        assert "must not decrease" in str(exc)
+    else:
+        raise AssertionError("cumulative KPI decrease must fail closed")
+
+
 def test_build_rejects_unhealthy_inputs(tmp_path, monkeypatch):
     calendar = tmp_path / "health.json"
     yahoo = tmp_path / "yahoo.json"


### PR DESCRIPTION
Closes #70

## What changed
- append `public/accepted-event-kpi.jsonl` from the existing registration audit step
- keep the log intentionally narrow: `generated_at`, `accepted_event_cumulative`, `delta`
- deduplicate reruns of the same snapshot
- fail closed if the cumulative KPI decreases
- add focused regression tests

This makes the KPI directly readable later without re-deriving growth from broader audit payloads.