### PR TITLE
fix: collapse duplicate source posts into canonical occurrences

### DIFF
--- a/.github/workflows/update-calendar-v2.yml
+++ b/.github/workflows/update-calendar-v2.yml
@@ -55,6 +55,7 @@ jobs:
           tests/test_vrchat_discovery_routes.py
           tests/test_category_ontology.py
           tests/test_registration_count_audit.py
+          tests/test_occurrence_dedup.py
       - name: Materialize curated recurring events
         run: python scripts/materialize_events.py
       - name: Discover public VRChat calendar events
@@ -89,6 +90,8 @@ jobs:
         run: python scripts/discover_event_links.py
       - name: Enrich official VRChat group images
         run: python scripts/enrich_vrchat_group_assets.py
+      - name: Collapse duplicate source posts into canonical occurrences
+        run: python scripts/deduplicate_occurrences.py
       - name: Render linked-image frontend and live ontologies
         run: python scripts/render_frontend.py
       - name: Build registration count audit
@@ -114,6 +117,7 @@ jobs:
           audit = json.loads(Path('public/yahoo-classifier-audit.json').read_text(encoding='utf-8'))
           registration = json.loads(Path('public/registration-count-audit.json').read_text(encoding='utf-8'))
           events = json.loads(Path('public/events.json').read_text(encoding='utf-8'))
+          duplicate_audit = json.loads(Path('public/event-duplicate-audit.json').read_text(encoding='utf-8'))
           assets = json.loads(Path('public/official-asset-audit.json').read_text(encoding='utf-8'))
           links = json.loads(Path('public/event-link-audit.json').read_text(encoding='utf-8'))
           groups = json.loads(Path('public/vrchat-group-asset-audit.json').read_text(encoding='utf-8'))
@@ -141,6 +145,27 @@ jobs:
           assert registration['latest']['yahoo_rejected_count'] == len(rejected)
           assert registration['latest']['yahoo_queries_failed'] == 0
           assert events['count'] == len(rows) and events['count'] > 555
+
+          assert duplicate_audit['schema_version'] == '1.0'
+          assert duplicate_audit['policy_version'] == 'canonical-occurrence.v1'
+          assert duplicate_audit['event_count_after'] == events['count']
+          assert duplicate_audit['event_count_before'] >= duplicate_audit['event_count_after']
+          assert duplicate_audit['duplicate_occurrence_count'] == (
+              duplicate_audit['event_count_before'] - duplicate_audit['event_count_after']
+          )
+          occurrence_ids = [row.get('occurrence_id') for row in rows]
+          source_record_ids = [row.get('source_record_id') for row in rows]
+          assert all(occurrence_ids)
+          assert all(source_record_ids)
+          assert len(occurrence_ids) == len(set(occurrence_ids))
+          ics_uids = [
+              line[4:]
+              for line in Path('public/calendar.ics').read_text(encoding='utf-8').splitlines()
+              if line.startswith('UID:')
+          ]
+          assert len(ics_uids) == events['count']
+          assert len(ics_uids) == len(set(ics_uids))
+
           assert assets['counts']['official_x'] > 0
           assert assets['counts']['webp_image'] > 0
           assert links['events_with_primary_action'] > 0
@@ -199,7 +224,7 @@ jobs:
           )
           if [ -n "$(git status --porcelain -- "${paths[@]}")" ]; then
             git config user.name github-actions[bot]
-            git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+            git config user.email 41898282+KAFKA2306@users.noreply.github.com
             git add "${paths[@]}"
             git commit -m 'chore: refresh calendar links images and ontology [skip ci]'
             git pull --rebase --autostash origin main

--- a/.github/workflows/update-calendar-v2.yml
+++ b/.github/workflows/update-calendar-v2.yml
@@ -224,7 +224,7 @@ jobs:
           )
           if [ -n "$(git status --porcelain -- "${paths[@]}")" ]; then
             git config user.name github-actions[bot]
-            git config user.email 41898282+KAFKA2306@users.noreply.github.com
+            git config user.email 41898282+github-actions[bot]@users.noreply.github.com
             git add "${paths[@]}"
             git commit -m 'chore: refresh calendar links images and ontology [skip ci]'
             git pull --rebase --autostash origin main

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,56 +1,87 @@
 # Architecture
 
-## Overview
+## Canonical responsibility
 
-This project is designed to collect event data from various online sources, integrate and validate the data, enhance it with AI, and publish it to different platforms.
+`KAFKA2306/cast_event_cal` is the source of truth for collection, normalization, classification, event identity, occurrence deduplication, ontology, and the canonical `public/` snapshot.
 
-## Components
+`KAFKA2306/vrc_cast_event_calender` is projection/delivery only. It must not implement an independent collector, classifier, ontology, or semantic deduplicator.
 
-1.  **Data Collection:**
-    *   **Playwright Scraper:** Uses Playwright to scrape data from websites.
-    *   **List Collector:** Collects data from lists.
+## Canonical data flow
 
-2.  **Data Integration:**
-    *   **Event Deduplicator:** Deduplicates events from different sources.
-    *   **Recurring Event Handler:** Handles recurring events.
-    *   **Schema Validator:** Validates data against a predefined schema.
+```text
+source collection
+  -> normalization
+  -> exact source-record deduplication
+  -> source/link/asset enrichment
+  -> canonical occurrence deduplication
+  -> ontology/category enrichment
+  -> public JSON + ICS + audits
+  -> projection repository
+```
 
-3.  **Data Processing:**
-    *   **AI Event Enhancer:** Enhances event information using AI.
-    *   **Event Info Extractor:** Extracts event information from text.
-    *   **Text Normalizer:** Normalizes text data.
+### 1. Source collection
 
-4.  **Data Publishing:**
-    *   **Calendar File Generator:** Generates calendar files (e.g., iCalendar).
-    *   **JSON API Generator:** Generates a JSON API for accessing the data.
-    *   **Web Content Updater:** Updates web content with the data.
+Collectors write source-specific observations under `data/`. Each source record keeps a stable provider identity where available, such as an X status ID, VRChat calendar event ID, ICS UID, or curated manual source ID.
 
-## Data Flow
+### 2. Normalization and exact source-record deduplication
 
-1.  Data is collected from online sources using the Data Collection components.
-2.  The collected data is integrated and validated using the Data Integration components.
-3.  The integrated data is processed and enhanced using the Data Processing components.
-4.  The processed data is published to different platforms using the Data Publishing components.
+`cast_event_cal/core.py` owns normalization and exact event-ID deduplication during the normalized calendar build. This phase only removes duplicate representations of the same source record.
 
-## Configuration
+It does **not** decide that two different source posts describe one real-world event occurrence.
 
-The project uses a configuration file (`config/main_config.yaml`) to manage settings and parameters. Scraping targets are defined in `config/scraping_targets.yaml`.
+### 3. Canonical occurrence deduplication
 
-## Data Storage
+`scripts/deduplicate_occurrences.py` is the authority for semantic occurrence resolution after source/link/asset enrichment and before frontend/ontology publication.
 
-Raw scraped data is stored in the `data/raw_scraped_data/` directory. Integrated and validated events are stored in the `data/validated_events/` directory. Published outputs are stored in the `data/published_outputs/` directory.
+It separates:
 
-## Models
+- `source_record_id`: one provider/source observation;
+- `occurrence_id`: one user-visible event occurrence;
+- `provenance[]`: all source observations collapsed into the occurrence.
 
-Data schemas are defined in `models/data_schemas.py`. The event data model is defined in `models/event_data_model.py`.
+Automatic merging is intentionally conservative. High-confidence evidence includes:
 
-## Common
+- the same source record;
+- the same canonical event URL and start time;
+- the same normalized description and start time;
+- the same sufficiently specific title and start time;
+- the same organizer, start time, occurrence ordinal, and sufficiently similar announcement text;
+- the same organizer/start time with a high announcement-text similarity threshold.
 
-The `src/common/` directory contains common modules used throughout the project, such as:
+Title similarity alone is not sufficient. Different dates, different ordinal numbers, or different organizers remain separate unless stronger evidence exists.
 
-*   `web_structure_analyzer.py`: Analyzes the structure of web pages.
-*   `adaptive_selectors.py`: Provides adaptive selectors for web scraping.
-*   `configuration_manager.py`: Manages configuration settings.
-*   `data_storage_handler.py`: Handles data storage operations.
-*   `error_handling.py`: Handles errors.
-*   `logger_setup.py`: Sets up logging.
+The deduplicator writes `public/event-duplicate-audit.json` with before/after counts, duplicate clusters, merge reasons, confidence, ambiguous candidates, and negative-control samples.
+
+### 4. Publication gate
+
+`.github/workflows/update-calendar-v2.yml` runs the occurrence deduplicator before `scripts/render_frontend.py` and validates:
+
+- every published row has `source_record_id` and `occurrence_id`;
+- `occurrence_id` is unique in `public/events.json`;
+- ICS UID count equals the published event count;
+- ICS UIDs are unique;
+- duplicate-audit before/after counts reconcile exactly.
+
+This makes `1 occurrence = 1 JSON row = 1 VEVENT` a publish-time invariant.
+
+## Identity policy
+
+Source identity and occurrence identity are deliberately distinct.
+
+A new repost, reminder post, or alternate source does not automatically create a new public event if deterministic evidence shows it refers to an already-known occurrence. Conversely, events are not merged merely because their titles are similar.
+
+For merged occurrences, all original source IDs and URLs remain available through `provenance[]` so deduplication never destroys source traceability.
+
+## Generated artifacts
+
+The canonical publication surface is `public/`. Important artifacts include:
+
+- `public/events.json`
+- `public/calendar.ics`
+- `public/health.json`
+- `public/event-duplicate-audit.json`
+- `public/event-ontology.json`
+- `public/category-ontology.json`
+- other source/classification/link/asset audit files
+
+Generated artifacts are evidence of a specific canonical run; they are not stronger than the source records and deterministic rules that produced them.

--- a/scripts/deduplicate_occurrences.py
+++ b/scripts/deduplicate_occurrences.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime
 from difflib import SequenceMatcher
+from itertools import combinations
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
@@ -64,9 +65,14 @@ def source_record_id(event: dict[str, Any]) -> str:
         return existing
     source = str(event.get("source") or "unknown").strip()
     source_id = str(event.get("source_id") or "").strip()
-    url = canonical_url(event.get("url")) or ""
+    url = canonical_url(event.get("url"))
     fallback = str(event.get("id") or "").strip()
-    payload = "|".join((source, source_id, url, fallback))
+    if source_id:
+        payload = f"{source}|source-id|{source_id}"
+    elif url:
+        payload = f"{source}|url|{url}"
+    else:
+        payload = f"{source}|event-id|{fallback}"
     return "src_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
 
 
@@ -79,7 +85,7 @@ def event_ordinal(event: dict[str, Any]) -> str | None:
     return match.group(1) if match else None
 
 
-def comparable_similarity(left: dict[str, Any], right: dict[str, Any]) -> float:
+def similarity(left: dict[str, Any], right: dict[str, Any]) -> float:
     left_text = normalize_text(event_text(left))
     right_text = normalize_text(event_text(right))
     if not left_text or not right_text:
@@ -87,7 +93,7 @@ def comparable_similarity(left: dict[str, Any], right: dict[str, Any]) -> float:
     return SequenceMatcher(None, left_text, right_text, autojunk=False).ratio()
 
 
-def same_occurrence_reason(
+def occurrence_match(
     left: dict[str, Any], right: dict[str, Any]
 ) -> tuple[str, float] | None:
     if str(left.get("starts_at") or "") != str(right.get("starts_at") or ""):
@@ -103,16 +109,8 @@ def same_occurrence_reason(
 
     left_description = normalize_text(left.get("description"))
     right_description = normalize_text(right.get("description"))
-    if (
-        len(left_description) >= 24
-        and left_description == right_description
-    ):
+    if len(left_description) >= 24 and left_description == right_description:
         return "exact_text_same_start", 0.99
-
-    left_title = normalize_text(left.get("title"))
-    right_title = normalize_text(right.get("title"))
-    if len(left_title) >= 20 and left_title == right_title:
-        return "exact_title_same_start", 0.97
 
     left_organizer = normalize_text(left.get("organizer"))
     right_organizer = normalize_text(right.get("organizer"))
@@ -124,42 +122,19 @@ def same_occurrence_reason(
     if (left_ordinal or right_ordinal) and left_ordinal != right_ordinal:
         return None
 
-    similarity = comparable_similarity(left, right)
-    if left_ordinal and right_ordinal and similarity >= 0.50:
+    score = similarity(left, right)
+    if left_ordinal and right_ordinal and score >= 0.50:
         return "same_organizer_same_start_ordinal", round(
-            min(0.96, 0.80 + similarity * 0.25), 4
+            min(0.96, 0.80 + score * 0.25), 4
         )
-    if similarity >= 0.72:
+    if score >= 0.75:
         return "same_organizer_same_start_high_similarity", round(
-            min(0.94, 0.74 + similarity * 0.25), 4
+            min(0.94, 0.74 + score * 0.25), 4
         )
     return None
 
 
-class UnionFind:
-    def __init__(self, size: int) -> None:
-        self.parent = list(range(size))
-        self.rank = [0] * size
-
-    def find(self, item: int) -> int:
-        while self.parent[item] != item:
-            self.parent[item] = self.parent[self.parent[item]]
-            item = self.parent[item]
-        return item
-
-    def union(self, left: int, right: int) -> None:
-        root_left = self.find(left)
-        root_right = self.find(right)
-        if root_left == root_right:
-            return
-        if self.rank[root_left] < self.rank[root_right]:
-            root_left, root_right = root_right, root_left
-        self.parent[root_right] = root_left
-        if self.rank[root_left] == self.rank[root_right]:
-            self.rank[root_left] += 1
-
-
-def completeness(event: dict[str, Any]) -> int:
+def representative_score(event: dict[str, Any]) -> tuple[Any, ...]:
     scalar_fields = (
         "organizer",
         "location",
@@ -171,37 +146,24 @@ def completeness(event: dict[str, Any]) -> int:
         "official_x_url",
         "official_website_url",
     )
-    score = sum(bool(event.get(field)) for field in scalar_fields)
-    score += min(3, len(event.get("official_links") or []))
-    score += min(2, len(event.get("related_links") or []))
-    return score
-
-
-def representative_score(event: dict[str, Any]) -> tuple[Any, ...]:
+    completeness = sum(bool(event.get(field)) for field in scalar_fields)
+    completeness += min(3, len(event.get("official_links") or []))
+    completeness += min(2, len(event.get("related_links") or []))
     return (
         SOURCE_PRIORITY.get(str(event.get("source") or ""), 0),
-        completeness(event),
+        completeness,
         float(event.get("confidence") or 0.0),
         str(event.get("fetched_at") or ""),
         source_record_id(event),
     )
 
 
-def unique_dicts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    selected: dict[str, dict[str, Any]] = {}
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        key = canonical_url(row.get("url")) or json.dumps(
-            row, ensure_ascii=False, sort_keys=True
-        )
-        selected.setdefault(key, deepcopy(row))
-    return [selected[key] for key in sorted(selected)]
-
-
-def provenance_for(event: dict[str, Any]) -> list[dict[str, Any]]:
-    existing = event.get("provenance")
-    rows = [deepcopy(row) for row in existing or [] if isinstance(row, dict)]
+def provenance(event: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = [
+        deepcopy(row)
+        for row in event.get("provenance") or []
+        if isinstance(row, dict)
+    ]
     rows.append(
         {
             "source_record_id": source_record_id(event),
@@ -222,7 +184,16 @@ def provenance_for(event: dict[str, Any]) -> list[dict[str, Any]]:
     return [selected[key] for key in sorted(selected)]
 
 
-def occurrence_id_for(
+def unique_link_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    selected: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        url = canonical_url(row.get("url"))
+        key = url or json.dumps(row, ensure_ascii=False, sort_keys=True)
+        selected.setdefault(key, deepcopy(row))
+    return [selected[key] for key in sorted(selected)]
+
+
+def occurrence_id(
     members: list[dict[str, Any]], reasons: list[str]
 ) -> str:
     existing = {
@@ -245,9 +216,7 @@ def occurrence_id_for(
 
     if len(urls) == 1 and "same_canonical_url" in reasons:
         payload = f"url|{start}|{next(iter(urls))}"
-    elif len(descriptions) == 1 and (
-        "exact_text_same_start" in reasons or "exact_title_same_start" in reasons
-    ):
+    elif len(descriptions) == 1 and "exact_text_same_start" in reasons:
         payload = f"text|{start}|{next(iter(descriptions))}"
     elif len(organizers) == 1 and len(ordinals) == 1:
         payload = (
@@ -255,34 +224,38 @@ def occurrence_id_for(
             f"{next(iter(ordinals))}"
         )
     else:
-        member_keys = "|".join(sorted(source_record_id(member) for member in members))
-        payload = f"members|{start}|{member_keys}"
+        payload = "members|" + start + "|" + "|".join(
+            sorted(source_record_id(member) for member in members)
+        )
     return "occ_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
 
 
-def merge_cluster(
-    members: list[dict[str, Any]], reasons: list[tuple[str, float]]
+def merge_members(
+    members: list[dict[str, Any]], matches: list[tuple[str, float]]
 ) -> dict[str, Any]:
-    representative = deepcopy(max(members, key=representative_score))
-    reason_names = sorted({reason for reason, _confidence in reasons})
-    occurrence_id = occurrence_id_for(members, reason_names)
+    row = deepcopy(max(members, key=representative_score))
+    representative_source_record_id = source_record_id(row)
+    reasons = sorted({reason for reason, _confidence in matches})
+    canonical_id = occurrence_id(members, reasons)
 
-    representative["id"] = occurrence_id
-    representative["occurrence_id"] = occurrence_id
-    representative["source_record_id"] = source_record_id(representative)
-    representative["provenance"] = []
-    for member in members:
-        representative["provenance"].extend(provenance_for(member))
-    representative["provenance"] = unique_dicts_by_source_record_id(
-        representative["provenance"]
-    )
-    representative["merged_source_count"] = len(representative["provenance"])
-    representative["merge_reason"] = reason_names
-    representative["merge_confidence"] = min(
-        (confidence for _reason, confidence in reasons), default=1.0
+    row["id"] = canonical_id
+    row["occurrence_id"] = canonical_id
+    row["source_record_id"] = representative_source_record_id
+    row["merge_reason"] = reasons
+    row["merge_confidence"] = min(
+        (confidence for _reason, confidence in matches), default=1.0
     )
 
-    representative["tags"] = sorted(
+    all_provenance = [entry for member in members for entry in provenance(member)]
+    selected_provenance: dict[str, dict[str, Any]] = {}
+    for entry in all_provenance:
+        selected_provenance.setdefault(str(entry["source_record_id"]), entry)
+    row["provenance"] = [
+        selected_provenance[key] for key in sorted(selected_provenance)
+    ]
+    row["merged_source_count"] = len(row["provenance"])
+
+    row["tags"] = sorted(
         {
             str(tag)
             for member in members
@@ -291,16 +264,17 @@ def merge_cluster(
         }
     )
     for field in ("official_links", "related_links"):
-        representative[field] = unique_dicts(
+        row[field] = unique_link_rows(
             [
-                row
+                link
                 for member in members
-                for row in member.get(field) or []
-                if isinstance(row, dict)
+                for link in member.get(field) or []
+                if isinstance(link, dict)
             ]
         )
 
-    fill_fields = (
+    ranked = sorted(members, key=representative_score, reverse=True)
+    for field in (
         "image_url",
         "image_kind",
         "primary_action_url",
@@ -311,98 +285,88 @@ def merge_cluster(
         "vrchat_group_image_url",
         "preferred_image_url",
         "preferred_image_kind",
-    )
-    ranked = sorted(members, key=representative_score, reverse=True)
-    for field in fill_fields:
-        if representative.get(field):
+    ):
+        if row.get(field):
             continue
-        for member in ranked:
-            if member.get(field):
-                representative[field] = deepcopy(member[field])
-                break
-    return representative
-
-
-def unique_dicts_by_source_record_id(
-    rows: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
-    selected: dict[str, dict[str, Any]] = {}
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        key = str(row.get("source_record_id") or "") or json.dumps(
-            row, ensure_ascii=False, sort_keys=True
+        row[field] = next(
+            (deepcopy(member[field]) for member in ranked if member.get(field)),
+            None,
         )
-        selected.setdefault(key, deepcopy(row))
-    return [selected[key] for key in sorted(selected)]
+    return row
 
 
-def duplicate_groups(
+def cluster_events(
     events: list[dict[str, Any]],
 ) -> tuple[list[list[int]], dict[tuple[int, int], tuple[str, float]], list[dict[str, Any]]]:
-    union_find = UnionFind(len(events))
-    edges: dict[tuple[int, int], tuple[str, float]] = {}
-    ambiguous: list[dict[str, Any]] = []
+    parent = list(range(len(events)))
+
+    def find(index: int) -> int:
+        while parent[index] != index:
+            parent[index] = parent[parent[index]]
+            index = parent[index]
+        return index
+
+    def union(left: int, right: int) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parent[right_root] = left_root
+
     by_start: dict[str, list[int]] = defaultdict(list)
     for index, event in enumerate(events):
         by_start[str(event.get("starts_at") or "")].append(index)
 
+    matches: dict[tuple[int, int], tuple[str, float]] = {}
+    ambiguous: list[dict[str, Any]] = []
     for indexes in by_start.values():
-        for offset, left_index in enumerate(indexes):
-            for right_index in indexes[offset + 1 :]:
-                left = events[left_index]
-                right = events[right_index]
-                reason = same_occurrence_reason(left, right)
-                if reason:
-                    union_find.union(left_index, right_index)
-                    edges[(left_index, right_index)] = reason
-                    continue
-                left_organizer = normalize_text(left.get("organizer"))
-                right_organizer = normalize_text(right.get("organizer"))
-                similarity = comparable_similarity(left, right)
-                if (
-                    left_organizer
-                    and left_organizer == right_organizer
-                    and similarity >= 0.45
-                ):
-                    ambiguous.append(
-                        {
-                            "left_id": left.get("id"),
-                            "right_id": right.get("id"),
-                            "starts_at": left.get("starts_at"),
-                            "organizer": left.get("organizer"),
-                            "similarity": round(similarity, 4),
-                            "left_title": left.get("title"),
-                            "right_title": right.get("title"),
-                        }
-                    )
+        for left, right in combinations(indexes, 2):
+            result = occurrence_match(events[left], events[right])
+            if result:
+                matches[(left, right)] = result
+                union(left, right)
+                continue
+            left_organizer = normalize_text(events[left].get("organizer"))
+            right_organizer = normalize_text(events[right].get("organizer"))
+            score = similarity(events[left], events[right])
+            if left_organizer and left_organizer == right_organizer and score >= 0.45:
+                ambiguous.append(
+                    {
+                        "left_id": events[left].get("id"),
+                        "right_id": events[right].get("id"),
+                        "starts_at": events[left].get("starts_at"),
+                        "organizer": events[left].get("organizer"),
+                        "similarity": round(score, 4),
+                        "left_title": events[left].get("title"),
+                        "right_title": events[right].get("title"),
+                    }
+                )
 
-    grouped: dict[int, list[int]] = defaultdict(list)
+    groups: dict[int, list[int]] = defaultdict(list)
     for index in range(len(events)):
-        grouped[union_find.find(index)].append(index)
-    groups = sorted(
-        (sorted(indexes) for indexes in grouped.values()),
-        key=lambda indexes: indexes[0],
+        groups[find(index)].append(index)
+    return (
+        sorted((sorted(group) for group in groups.values()), key=lambda group: group[0]),
+        matches,
+        sorted(
+            ambiguous,
+            key=lambda row: (
+                str(row.get("starts_at")),
+                str(row.get("organizer")),
+                str(row.get("left_id")),
+                str(row.get("right_id")),
+            ),
+        )[:100],
     )
-    ambiguous.sort(
-        key=lambda row: (
-            str(row.get("starts_at")),
-            str(row.get("organizer")),
-            str(row.get("left_id")),
-            str(row.get("right_id")),
-        )
-    )
-    return groups, edges, ambiguous[:100]
 
 
 def deduplicate_events(
     events: list[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     working = [deepcopy(event) for event in events if isinstance(event, dict)]
-    groups, edges, ambiguous = duplicate_groups(working)
+    groups, matches, ambiguous = cluster_events(working)
     output: list[dict[str, Any]] = []
-    cluster_audit: list[dict[str, Any]] = []
-    negative_samples: list[dict[str, Any]] = []
+    clusters: list[dict[str, Any]] = []
+    merged_pairs: set[tuple[str, str]] = set()
 
     for indexes in groups:
         members = [working[index] for index in indexes]
@@ -410,91 +374,89 @@ def deduplicate_events(
             row = deepcopy(members[0])
             row["source_record_id"] = source_record_id(row)
             row["occurrence_id"] = str(row.get("occurrence_id") or row.get("id"))
+            row.setdefault("provenance", provenance(row))
+            row.setdefault("merged_source_count", len(row["provenance"]))
+            row.setdefault("merge_reason", [])
+            row.setdefault("merge_confidence", 1.0)
             output.append(row)
             continue
 
-        member_edges = [
-            reason
-            for (left, right), reason in edges.items()
+        member_matches = [
+            result
+            for (left, right), result in matches.items()
             if left in indexes and right in indexes
         ]
-        merged = merge_cluster(members, member_edges)
+        merged = merge_members(members, member_matches)
         output.append(merged)
-        cluster_audit.append(
+        member_ids = sorted(str(member.get("id")) for member in members)
+        merged_pairs.update(tuple(sorted(pair)) for pair in combinations(member_ids, 2))
+        clusters.append(
             {
                 "cluster_id": merged["occurrence_id"],
                 "starts_at": merged.get("starts_at"),
                 "title": merged.get("title"),
                 "member_count": len(members),
-                "member_ids": sorted(str(member.get("id")) for member in members),
+                "member_ids": member_ids,
                 "source_record_ids": sorted(source_record_id(member) for member in members),
                 "sources": sorted({str(member.get("source")) for member in members}),
-                "reasons": sorted({reason for reason, _confidence in member_edges}),
+                "reasons": sorted({reason for reason, _confidence in member_matches}),
                 "confidence": min(
-                    (confidence for _reason, confidence in member_edges), default=1.0
+                    (confidence for _reason, confidence in member_matches), default=1.0
                 ),
                 "representative_source_record_id": merged["source_record_id"],
             }
         )
 
-    merged_pairs = {
-        tuple(sorted((str(row["member_ids"][0]), str(member_id))))
-        for row in cluster_audit
-        for member_id in row["member_ids"][1:]
-    }
+    negative_samples: list[dict[str, Any]] = []
     by_start: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for event in working:
         by_start[str(event.get("starts_at") or "")].append(event)
     for rows in by_start.values():
-        for offset, left in enumerate(rows):
-            for right in rows[offset + 1 :]:
-                pair = tuple(sorted((str(left.get("id")), str(right.get("id")))))
-                if pair in merged_pairs:
-                    continue
-                negative_samples.append(
-                    {
-                        "left_id": left.get("id"),
-                        "right_id": right.get("id"),
-                        "starts_at": left.get("starts_at"),
-                        "left_organizer": left.get("organizer"),
-                        "right_organizer": right.get("organizer"),
-                        "similarity": round(comparable_similarity(left, right), 4),
-                        "left_title": left.get("title"),
-                        "right_title": right.get("title"),
-                    }
-                )
-                if len(negative_samples) >= 10:
-                    break
-            if len(negative_samples) >= 10:
+        for left, right in combinations(rows, 2):
+            pair = tuple(sorted((str(left.get("id")), str(right.get("id")))))
+            if pair in merged_pairs:
+                continue
+            negative_samples.append(
+                {
+                    "left_id": left.get("id"),
+                    "right_id": right.get("id"),
+                    "starts_at": left.get("starts_at"),
+                    "left_organizer": left.get("organizer"),
+                    "right_organizer": right.get("organizer"),
+                    "similarity": round(similarity(left, right), 4),
+                    "left_title": left.get("title"),
+                    "right_title": right.get("title"),
+                }
+            )
+            if len(negative_samples) == 10:
                 break
-        if len(negative_samples) >= 10:
+        if len(negative_samples) == 10:
             break
 
     output.sort(key=lambda row: (str(row.get("starts_at")), str(row.get("title"))))
     collapsed = len(working) - len(output)
-    exact_source_duplicate_count = sum(
-        "exact_source_record" in row["reasons"] for row in cluster_audit
-    )
     audit = {
         "schema_version": "1.0",
         "policy_version": "canonical-occurrence.v1",
         "event_count_before": len(working),
         "event_count_after": len(output),
-        "candidate_cluster_count": len(cluster_audit),
-        "duplicate_cluster_count": len(cluster_audit),
+        "candidate_cluster_count": len(clusters),
+        "duplicate_cluster_count": len(clusters),
         "duplicate_occurrence_count": collapsed,
         "duplicate_post_count": collapsed,
         "duplicate_rate": round(collapsed / len(working), 6) if working else 0.0,
-        "exact_source_duplicate_count": exact_source_duplicate_count,
+        "exact_source_duplicate_count": sum(
+            "exact_source_record" in cluster["reasons"] for cluster in clusters
+        ),
         "unresolved_ambiguous_cluster_count": len(ambiguous),
-        "clusters": sorted(cluster_audit, key=lambda row: str(row["cluster_id"])),
+        "clusters": sorted(clusters, key=lambda row: str(row["cluster_id"])),
         "ambiguous_candidates": ambiguous,
         "negative_samples": negative_samples,
     }
     return output, audit
 
 
-def event_from_public_row(row: dict[str, Any]) -> Event:
+def public_event(row: dict[str, Any]) -> Event:
     return Event(
         id=str(row.get("occurrence_id") or row.get("id")),
         title=str(row.get("title") or "VRChat event"),
@@ -516,12 +478,6 @@ def event_from_public_row(row: dict[str, Any]) -> Event:
     ).normalized()
 
 
-def rewrite_ics(rows: list[dict[str, Any]], generated_at: str, output: Path) -> None:
-    instant = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
-    events = [event_from_public_row(row) for row in rows]
-    output.write_text(render_ics(events, instant), encoding="utf-8", newline="")
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Collapse duplicate source posts into canonical event occurrences"
@@ -533,22 +489,25 @@ def main() -> int:
 
     document = json.loads(args.events.read_text(encoding="utf-8"))
     rows = document.get("events", [])
+    generated_at = str(document.get("generated_at") or "")
     if not isinstance(rows, list):
         raise ValueError("events document must contain an events array")
-    deduped, audit = deduplicate_events(rows)
-    generated_at = str(document.get("generated_at") or "")
     if not generated_at:
         raise ValueError("events document must contain generated_at")
 
+    deduped, audit = deduplicate_events(rows)
     audit["generated_at"] = generated_at
     document["events"] = deduped
     document["count"] = len(deduped)
     document["occurrence_dedup"] = {
-        "policy_version": audit["policy_version"],
-        "event_count_before": audit["event_count_before"],
-        "event_count_after": audit["event_count_after"],
-        "duplicate_occurrence_count": audit["duplicate_occurrence_count"],
-        "duplicate_cluster_count": audit["duplicate_cluster_count"],
+        key: audit[key]
+        for key in (
+            "policy_version",
+            "event_count_before",
+            "event_count_after",
+            "duplicate_occurrence_count",
+            "duplicate_cluster_count",
+        )
     }
 
     args.events.write_text(
@@ -557,7 +516,12 @@ def main() -> int:
     args.audit.write_text(
         json.dumps(audit, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
     )
-    rewrite_ics(deduped, generated_at, args.ics)
+    generated = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    args.ics.write_text(
+        render_ics([public_event(row) for row in deduped], generated),
+        encoding="utf-8",
+        newline="",
+    )
     print(
         "Occurrence dedup: "
         f"before={audit['event_count_before']} after={audit['event_count_after']} "

--- a/scripts/deduplicate_occurrences.py
+++ b/scripts/deduplicate_occurrences.py
@@ -1,0 +1,571 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import unicodedata
+from collections import defaultdict
+from copy import deepcopy
+from datetime import datetime
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+from cast_event_cal.core import Event, render_ics
+
+DEFAULT_EVENTS = Path("public/events.json")
+DEFAULT_ICS = Path("public/calendar.ics")
+DEFAULT_AUDIT = Path("public/event-duplicate-audit.json")
+
+SOURCE_PRIORITY = {
+    "repository_manual_events": 50,
+    "vrchat_calendar_discovery": 45,
+    "external_calendar_events": 40,
+    "x_curated_events": 30,
+    "yahoo_realtime_events": 20,
+}
+
+URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+ORDINAL_RE = re.compile(r"第\s*(\d{1,4})\s*回")
+SPACE_RE = re.compile(r"\s+")
+NON_WORD_RE = re.compile(r"[^0-9a-zぁ-んァ-ヶ一-龠]+", re.IGNORECASE)
+
+
+def normalize_text(value: Any) -> str:
+    text = unicodedata.normalize("NFKC", str(value or "")).casefold()
+    text = URL_RE.sub("", text)
+    text = SPACE_RE.sub("", text)
+    return NON_WORD_RE.sub("", text)
+
+
+def canonical_url(value: Any) -> str | None:
+    raw = str(value or "").strip()
+    if not raw.startswith("https://"):
+        return None
+    parsed = urlparse(raw)
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return None
+    if host in {"twitter.com", "www.twitter.com", "www.x.com"}:
+        host = "x.com"
+    query = [
+        (key, val)
+        for key, val in parse_qsl(parsed.query, keep_blank_values=True)
+        if not key.casefold().startswith("utm_")
+    ]
+    return urlunparse(("https", host, parsed.path.rstrip("/"), "", urlencode(query), ""))
+
+
+def source_record_id(event: dict[str, Any]) -> str:
+    existing = str(event.get("source_record_id") or "").strip()
+    if existing:
+        return existing
+    source = str(event.get("source") or "unknown").strip()
+    source_id = str(event.get("source_id") or "").strip()
+    url = canonical_url(event.get("url")) or ""
+    fallback = str(event.get("id") or "").strip()
+    payload = "|".join((source, source_id, url, fallback))
+    return "src_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
+
+
+def event_text(event: dict[str, Any]) -> str:
+    return str(event.get("description") or event.get("title") or "")
+
+
+def event_ordinal(event: dict[str, Any]) -> str | None:
+    match = ORDINAL_RE.search(unicodedata.normalize("NFKC", event_text(event)))
+    return match.group(1) if match else None
+
+
+def comparable_similarity(left: dict[str, Any], right: dict[str, Any]) -> float:
+    left_text = normalize_text(event_text(left))
+    right_text = normalize_text(event_text(right))
+    if not left_text or not right_text:
+        return 0.0
+    return SequenceMatcher(None, left_text, right_text, autojunk=False).ratio()
+
+
+def same_occurrence_reason(
+    left: dict[str, Any], right: dict[str, Any]
+) -> tuple[str, float] | None:
+    if str(left.get("starts_at") or "") != str(right.get("starts_at") or ""):
+        return None
+
+    if source_record_id(left) == source_record_id(right):
+        return "exact_source_record", 1.0
+
+    left_url = canonical_url(left.get("url"))
+    right_url = canonical_url(right.get("url"))
+    if left_url and left_url == right_url:
+        return "same_canonical_url", 1.0
+
+    left_description = normalize_text(left.get("description"))
+    right_description = normalize_text(right.get("description"))
+    if (
+        len(left_description) >= 24
+        and left_description == right_description
+    ):
+        return "exact_text_same_start", 0.99
+
+    left_title = normalize_text(left.get("title"))
+    right_title = normalize_text(right.get("title"))
+    if len(left_title) >= 20 and left_title == right_title:
+        return "exact_title_same_start", 0.97
+
+    left_organizer = normalize_text(left.get("organizer"))
+    right_organizer = normalize_text(right.get("organizer"))
+    if not left_organizer or left_organizer != right_organizer:
+        return None
+
+    left_ordinal = event_ordinal(left)
+    right_ordinal = event_ordinal(right)
+    if (left_ordinal or right_ordinal) and left_ordinal != right_ordinal:
+        return None
+
+    similarity = comparable_similarity(left, right)
+    if left_ordinal and right_ordinal and similarity >= 0.50:
+        return "same_organizer_same_start_ordinal", round(
+            min(0.96, 0.80 + similarity * 0.25), 4
+        )
+    if similarity >= 0.72:
+        return "same_organizer_same_start_high_similarity", round(
+            min(0.94, 0.74 + similarity * 0.25), 4
+        )
+    return None
+
+
+class UnionFind:
+    def __init__(self, size: int) -> None:
+        self.parent = list(range(size))
+        self.rank = [0] * size
+
+    def find(self, item: int) -> int:
+        while self.parent[item] != item:
+            self.parent[item] = self.parent[self.parent[item]]
+            item = self.parent[item]
+        return item
+
+    def union(self, left: int, right: int) -> None:
+        root_left = self.find(left)
+        root_right = self.find(right)
+        if root_left == root_right:
+            return
+        if self.rank[root_left] < self.rank[root_right]:
+            root_left, root_right = root_right, root_left
+        self.parent[root_right] = root_left
+        if self.rank[root_left] == self.rank[root_right]:
+            self.rank[root_left] += 1
+
+
+def completeness(event: dict[str, Any]) -> int:
+    scalar_fields = (
+        "organizer",
+        "location",
+        "description",
+        "url",
+        "image_url",
+        "primary_action_url",
+        "vrchat_group_url",
+        "official_x_url",
+        "official_website_url",
+    )
+    score = sum(bool(event.get(field)) for field in scalar_fields)
+    score += min(3, len(event.get("official_links") or []))
+    score += min(2, len(event.get("related_links") or []))
+    return score
+
+
+def representative_score(event: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        SOURCE_PRIORITY.get(str(event.get("source") or ""), 0),
+        completeness(event),
+        float(event.get("confidence") or 0.0),
+        str(event.get("fetched_at") or ""),
+        source_record_id(event),
+    )
+
+
+def unique_dicts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    selected: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        key = canonical_url(row.get("url")) or json.dumps(
+            row, ensure_ascii=False, sort_keys=True
+        )
+        selected.setdefault(key, deepcopy(row))
+    return [selected[key] for key in sorted(selected)]
+
+
+def provenance_for(event: dict[str, Any]) -> list[dict[str, Any]]:
+    existing = event.get("provenance")
+    rows = [deepcopy(row) for row in existing or [] if isinstance(row, dict)]
+    rows.append(
+        {
+            "source_record_id": source_record_id(event),
+            "event_id": event.get("id"),
+            "source": event.get("source"),
+            "source_id": event.get("source_id"),
+            "url": event.get("url"),
+            "organizer": event.get("organizer"),
+            "fetched_at": event.get("fetched_at"),
+        }
+    )
+    selected: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        key = str(row.get("source_record_id") or "") or json.dumps(
+            row, ensure_ascii=False, sort_keys=True
+        )
+        selected.setdefault(key, row)
+    return [selected[key] for key in sorted(selected)]
+
+
+def occurrence_id_for(
+    members: list[dict[str, Any]], reasons: list[str]
+) -> str:
+    existing = {
+        str(member.get("occurrence_id") or "").strip()
+        for member in members
+        if member.get("occurrence_id")
+    }
+    if len(existing) == 1:
+        return next(iter(existing))
+
+    start = str(members[0].get("starts_at") or "")
+    urls = {canonical_url(member.get("url")) for member in members}
+    urls.discard(None)
+    descriptions = {normalize_text(member.get("description")) for member in members}
+    descriptions.discard("")
+    organizers = {normalize_text(member.get("organizer")) for member in members}
+    organizers.discard("")
+    ordinals = {event_ordinal(member) for member in members}
+    ordinals.discard(None)
+
+    if len(urls) == 1 and "same_canonical_url" in reasons:
+        payload = f"url|{start}|{next(iter(urls))}"
+    elif len(descriptions) == 1 and (
+        "exact_text_same_start" in reasons or "exact_title_same_start" in reasons
+    ):
+        payload = f"text|{start}|{next(iter(descriptions))}"
+    elif len(organizers) == 1 and len(ordinals) == 1:
+        payload = (
+            f"organizer-ordinal|{start}|{next(iter(organizers))}|"
+            f"{next(iter(ordinals))}"
+        )
+    else:
+        member_keys = "|".join(sorted(source_record_id(member) for member in members))
+        payload = f"members|{start}|{member_keys}"
+    return "occ_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
+
+
+def merge_cluster(
+    members: list[dict[str, Any]], reasons: list[tuple[str, float]]
+) -> dict[str, Any]:
+    representative = deepcopy(max(members, key=representative_score))
+    reason_names = sorted({reason for reason, _confidence in reasons})
+    occurrence_id = occurrence_id_for(members, reason_names)
+
+    representative["id"] = occurrence_id
+    representative["occurrence_id"] = occurrence_id
+    representative["source_record_id"] = source_record_id(representative)
+    representative["provenance"] = []
+    for member in members:
+        representative["provenance"].extend(provenance_for(member))
+    representative["provenance"] = unique_dicts_by_source_record_id(
+        representative["provenance"]
+    )
+    representative["merged_source_count"] = len(representative["provenance"])
+    representative["merge_reason"] = reason_names
+    representative["merge_confidence"] = min(
+        (confidence for _reason, confidence in reasons), default=1.0
+    )
+
+    representative["tags"] = sorted(
+        {
+            str(tag)
+            for member in members
+            for tag in member.get("tags") or []
+            if str(tag).strip()
+        }
+    )
+    for field in ("official_links", "related_links"):
+        representative[field] = unique_dicts(
+            [
+                row
+                for member in members
+                for row in member.get(field) or []
+                if isinstance(row, dict)
+            ]
+        )
+
+    fill_fields = (
+        "image_url",
+        "image_kind",
+        "primary_action_url",
+        "primary_action_kind",
+        "official_x_url",
+        "official_website_url",
+        "vrchat_group_url",
+        "vrchat_group_image_url",
+        "preferred_image_url",
+        "preferred_image_kind",
+    )
+    ranked = sorted(members, key=representative_score, reverse=True)
+    for field in fill_fields:
+        if representative.get(field):
+            continue
+        for member in ranked:
+            if member.get(field):
+                representative[field] = deepcopy(member[field])
+                break
+    return representative
+
+
+def unique_dicts_by_source_record_id(
+    rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    selected: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        key = str(row.get("source_record_id") or "") or json.dumps(
+            row, ensure_ascii=False, sort_keys=True
+        )
+        selected.setdefault(key, deepcopy(row))
+    return [selected[key] for key in sorted(selected)]
+
+
+def duplicate_groups(
+    events: list[dict[str, Any]],
+) -> tuple[list[list[int]], dict[tuple[int, int], tuple[str, float]], list[dict[str, Any]]]:
+    union_find = UnionFind(len(events))
+    edges: dict[tuple[int, int], tuple[str, float]] = {}
+    ambiguous: list[dict[str, Any]] = []
+    by_start: dict[str, list[int]] = defaultdict(list)
+    for index, event in enumerate(events):
+        by_start[str(event.get("starts_at") or "")].append(index)
+
+    for indexes in by_start.values():
+        for offset, left_index in enumerate(indexes):
+            for right_index in indexes[offset + 1 :]:
+                left = events[left_index]
+                right = events[right_index]
+                reason = same_occurrence_reason(left, right)
+                if reason:
+                    union_find.union(left_index, right_index)
+                    edges[(left_index, right_index)] = reason
+                    continue
+                left_organizer = normalize_text(left.get("organizer"))
+                right_organizer = normalize_text(right.get("organizer"))
+                similarity = comparable_similarity(left, right)
+                if (
+                    left_organizer
+                    and left_organizer == right_organizer
+                    and similarity >= 0.45
+                ):
+                    ambiguous.append(
+                        {
+                            "left_id": left.get("id"),
+                            "right_id": right.get("id"),
+                            "starts_at": left.get("starts_at"),
+                            "organizer": left.get("organizer"),
+                            "similarity": round(similarity, 4),
+                            "left_title": left.get("title"),
+                            "right_title": right.get("title"),
+                        }
+                    )
+
+    grouped: dict[int, list[int]] = defaultdict(list)
+    for index in range(len(events)):
+        grouped[union_find.find(index)].append(index)
+    groups = sorted(
+        (sorted(indexes) for indexes in grouped.values()),
+        key=lambda indexes: indexes[0],
+    )
+    ambiguous.sort(
+        key=lambda row: (
+            str(row.get("starts_at")),
+            str(row.get("organizer")),
+            str(row.get("left_id")),
+            str(row.get("right_id")),
+        )
+    )
+    return groups, edges, ambiguous[:100]
+
+
+def deduplicate_events(
+    events: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    working = [deepcopy(event) for event in events if isinstance(event, dict)]
+    groups, edges, ambiguous = duplicate_groups(working)
+    output: list[dict[str, Any]] = []
+    cluster_audit: list[dict[str, Any]] = []
+    negative_samples: list[dict[str, Any]] = []
+
+    for indexes in groups:
+        members = [working[index] for index in indexes]
+        if len(members) == 1:
+            row = deepcopy(members[0])
+            row["source_record_id"] = source_record_id(row)
+            row["occurrence_id"] = str(row.get("occurrence_id") or row.get("id"))
+            output.append(row)
+            continue
+
+        member_edges = [
+            reason
+            for (left, right), reason in edges.items()
+            if left in indexes and right in indexes
+        ]
+        merged = merge_cluster(members, member_edges)
+        output.append(merged)
+        cluster_audit.append(
+            {
+                "cluster_id": merged["occurrence_id"],
+                "starts_at": merged.get("starts_at"),
+                "title": merged.get("title"),
+                "member_count": len(members),
+                "member_ids": sorted(str(member.get("id")) for member in members),
+                "source_record_ids": sorted(source_record_id(member) for member in members),
+                "sources": sorted({str(member.get("source")) for member in members}),
+                "reasons": sorted({reason for reason, _confidence in member_edges}),
+                "confidence": min(
+                    (confidence for _reason, confidence in member_edges), default=1.0
+                ),
+                "representative_source_record_id": merged["source_record_id"],
+            }
+        )
+
+    merged_pairs = {
+        tuple(sorted((str(row["member_ids"][0]), str(member_id))))
+        for row in cluster_audit
+        for member_id in row["member_ids"][1:]
+    }
+    by_start: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for event in working:
+        by_start[str(event.get("starts_at") or "")].append(event)
+    for rows in by_start.values():
+        for offset, left in enumerate(rows):
+            for right in rows[offset + 1 :]:
+                pair = tuple(sorted((str(left.get("id")), str(right.get("id")))))
+                if pair in merged_pairs:
+                    continue
+                negative_samples.append(
+                    {
+                        "left_id": left.get("id"),
+                        "right_id": right.get("id"),
+                        "starts_at": left.get("starts_at"),
+                        "left_organizer": left.get("organizer"),
+                        "right_organizer": right.get("organizer"),
+                        "similarity": round(comparable_similarity(left, right), 4),
+                        "left_title": left.get("title"),
+                        "right_title": right.get("title"),
+                    }
+                )
+                if len(negative_samples) >= 10:
+                    break
+            if len(negative_samples) >= 10:
+                break
+        if len(negative_samples) >= 10:
+            break
+
+    output.sort(key=lambda row: (str(row.get("starts_at")), str(row.get("title"))))
+    collapsed = len(working) - len(output)
+    exact_source_duplicate_count = sum(
+        "exact_source_record" in row["reasons"] for row in cluster_audit
+    )
+    audit = {
+        "schema_version": "1.0",
+        "policy_version": "canonical-occurrence.v1",
+        "event_count_before": len(working),
+        "event_count_after": len(output),
+        "candidate_cluster_count": len(cluster_audit),
+        "duplicate_cluster_count": len(cluster_audit),
+        "duplicate_occurrence_count": collapsed,
+        "duplicate_post_count": collapsed,
+        "duplicate_rate": round(collapsed / len(working), 6) if working else 0.0,
+        "exact_source_duplicate_count": exact_source_duplicate_count,
+        "unresolved_ambiguous_cluster_count": len(ambiguous),
+        "clusters": sorted(cluster_audit, key=lambda row: str(row["cluster_id"])),
+        "ambiguous_candidates": ambiguous,
+        "negative_samples": negative_samples,
+    }
+    return output, audit
+
+
+def event_from_public_row(row: dict[str, Any]) -> Event:
+    return Event(
+        id=str(row.get("occurrence_id") or row.get("id")),
+        title=str(row.get("title") or "VRChat event"),
+        starts_at=str(row["starts_at"]),
+        ends_at=row.get("ends_at"),
+        organizer=row.get("organizer"),
+        location=row.get("location"),
+        description=row.get("description"),
+        url=row.get("url"),
+        image_url=row.get("image_url"),
+        category=row.get("category"),
+        status=str(row.get("status") or "scheduled"),
+        source=str(row.get("source") or "unknown"),
+        source_id=row.get("source_id"),
+        fetched_at=row.get("fetched_at"),
+        tags=list(row.get("tags") or []),
+        confidence=float(row.get("confidence") or 0.0),
+        review_required=bool(row.get("review_required", False)),
+    ).normalized()
+
+
+def rewrite_ics(rows: list[dict[str, Any]], generated_at: str, output: Path) -> None:
+    instant = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    events = [event_from_public_row(row) for row in rows]
+    output.write_text(render_ics(events, instant), encoding="utf-8", newline="")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Collapse duplicate source posts into canonical event occurrences"
+    )
+    parser.add_argument("--events", type=Path, default=DEFAULT_EVENTS)
+    parser.add_argument("--ics", type=Path, default=DEFAULT_ICS)
+    parser.add_argument("--audit", type=Path, default=DEFAULT_AUDIT)
+    args = parser.parse_args()
+
+    document = json.loads(args.events.read_text(encoding="utf-8"))
+    rows = document.get("events", [])
+    if not isinstance(rows, list):
+        raise ValueError("events document must contain an events array")
+    deduped, audit = deduplicate_events(rows)
+    generated_at = str(document.get("generated_at") or "")
+    if not generated_at:
+        raise ValueError("events document must contain generated_at")
+
+    audit["generated_at"] = generated_at
+    document["events"] = deduped
+    document["count"] = len(deduped)
+    document["occurrence_dedup"] = {
+        "policy_version": audit["policy_version"],
+        "event_count_before": audit["event_count_before"],
+        "event_count_after": audit["event_count_after"],
+        "duplicate_occurrence_count": audit["duplicate_occurrence_count"],
+        "duplicate_cluster_count": audit["duplicate_cluster_count"],
+    }
+
+    args.events.write_text(
+        json.dumps(document, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    args.audit.write_text(
+        json.dumps(audit, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    rewrite_ics(deduped, generated_at, args.ics)
+    print(
+        "Occurrence dedup: "
+        f"before={audit['event_count_before']} after={audit['event_count_after']} "
+        f"collapsed={audit['duplicate_occurrence_count']} "
+        f"clusters={audit['duplicate_cluster_count']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data_integration/event_deduplicator.py
+++ b/src/data_integration/event_deduplicator.py
@@ -1,7 +1,0 @@
-# src/data_integration/event_deduplicator.py
-class EventDuplicateHandler:
-    def __init__(self, config_manager):
-        self.config_manager = config_manager
-
-    def deduplicate(self, events):
-        return events

--- a/tests/test_occurrence_dedup.py
+++ b/tests/test_occurrence_dedup.py
@@ -1,0 +1,194 @@
+from scripts.deduplicate_occurrences import deduplicate_events
+
+
+def event(
+    *,
+    event_id: str,
+    source_id: str,
+    title: str,
+    description: str,
+    starts_at: str = "2026-08-15T13:00:00Z",
+    organizer: str = "@host",
+    url: str | None = None,
+) -> dict:
+    return {
+        "id": event_id,
+        "source": "yahoo_realtime_events",
+        "source_id": source_id,
+        "title": title,
+        "description": description,
+        "starts_at": starts_at,
+        "organizer": organizer,
+        "location": "VRChat",
+        "url": url or f"https://x.com/{organizer.lstrip('@')}/status/{source_id}",
+        "status": "scheduled",
+        "tags": ["VRChat", "Yahoo!リアルタイム検索"],
+        "confidence": 0.9,
+        "fetched_at": "2026-08-15T10:01:32Z",
+    }
+
+
+def test_same_text_same_start_cross_organizer_collapses_to_one_occurrence():
+    description = (
+        "【！VRChat イベント告知！】 「なんと、18ちゃんの誕生日！」 "
+        "18ちゃん2周年記念イベント開催！ 1周年記念から会場が進化しました！ "
+        "ぜひ18ちゃんユーザー達で集まってお話しましょう！ PC、Quest両対応なので"
+        "気軽に来てください！ 日時: 8/15(土) 22:00〜 場所: グループインスタンス END"
+    )
+    rows = [
+        event(
+            event_id="1cf39843d8850c5d5159",
+            source_id="yahoo:x:2088231134018867622",
+            organizer="@18_khsnhonbu",
+            title="18ちゃん2周年記念イベント開催！",
+            description=description,
+        ),
+        event(
+            event_id="37fb72a1a34e952bd00a",
+            source_id="yahoo:x:2088293741744263229",
+            organizer="@Livia14481176",
+            title="18ちゃん2周年記念イベント開催！",
+            description=description,
+        ),
+    ]
+
+    deduped, audit = deduplicate_events(rows)
+
+    assert len(deduped) == 1
+    assert deduped[0]["id"] == deduped[0]["occurrence_id"]
+    assert deduped[0]["merged_source_count"] == 2
+    assert len(deduped[0]["provenance"]) == 2
+    assert audit["duplicate_occurrence_count"] == 1
+    assert audit["clusters"][0]["reasons"] == ["exact_text_same_start"]
+
+
+def test_same_organizer_same_start_same_ordinal_collapses_updated_announcement():
+    first = event(
+        event_id="1f7566d3f86a1a581901",
+        source_id="yahoo:x:2087828658388111441",
+        organizer="@0zoku_vrc",
+        title="START VRCイベント 〜０属オークション〜 第4回開催 RT招待キャンペーン",
+        description=(
+            "START VRCイベント 〜０属オークション〜 第4回開催 RT招待キャンペーン！ "
+            "開催日時 8/15(土) 22:00 リクイン抽選式 参加条件は5万UC以上。 "
+            "参加方法: リクイン抽選式。参加条件と観戦条件は各回の公式告知を確認。 "
+            "開催形式: VRChat内オークションイベント 対象: 所定のUC所持条件を満たす参加者・観戦者"
+        ),
+    )
+    second = event(
+        event_id="4ba1973663bfa8149dbe",
+        source_id="yahoo:x:2088561328206262511",
+        organizer="@0zoku_vrc",
+        title="START VRCオークションイベント 『０属オークション』 本日22:00 第4回開催",
+        description=(
+            "START VRCオークションイベント 『０属オークション』 本日22:00 第4回開催 "
+            "出品サキュバス公開 参加方法 時間になったらインスタンスリーダーに1回リクイン。 "
+            "参加方法: リクイン抽選式。参加条件と観戦条件は各回の公式告知を確認。 "
+            "開催形式: VRChat内オークションイベント 対象: 所定のUC所持条件を満たす参加者・観戦者"
+        ),
+    )
+
+    deduped, audit = deduplicate_events([first, second])
+
+    assert len(deduped) == 1
+    assert deduped[0]["merged_source_count"] == 2
+    assert audit["duplicate_occurrence_count"] == 1
+    assert "same_organizer_same_start_ordinal" in audit["clusters"][0]["reasons"]
+
+
+def test_same_series_different_date_is_not_merged():
+    rows = [
+        event(
+            event_id="auction-4",
+            source_id="post-4",
+            title="０属オークション 第4回開催",
+            description="０属オークション 第4回開催 8/15 22:00 参加方法はリクイン",
+        ),
+        event(
+            event_id="auction-5",
+            source_id="post-5",
+            title="０属オークション 第5回開催",
+            description="０属オークション 第5回開催 8/22 22:00 参加方法はリクイン",
+            starts_at="2026-08-22T13:00:00Z",
+        ),
+    ]
+
+    deduped, audit = deduplicate_events(rows)
+
+    assert len(deduped) == 2
+    assert audit["duplicate_occurrence_count"] == 0
+
+
+def test_same_start_similar_title_different_organizer_is_not_merged():
+    rows = [
+        event(
+            event_id="beginner-a",
+            source_id="post-a",
+            organizer="@alpha",
+            title="VRChat初心者交流会",
+            description="VRChat初心者交流会です。初参加者向けに操作説明と交流を行います。",
+        ),
+        event(
+            event_id="beginner-b",
+            source_id="post-b",
+            organizer="@beta",
+            title="VRChat初心者交流会",
+            description="VRChat初心者交流会です。写真撮影とワールド巡りを中心に交流します。",
+        ),
+    ]
+
+    deduped, audit = deduplicate_events(rows)
+
+    assert len(deduped) == 2
+    assert audit["duplicate_occurrence_count"] == 0
+
+
+def test_same_organizer_same_start_different_ordinal_is_not_merged():
+    rows = [
+        event(
+            event_id="round-4",
+            source_id="round-post-4",
+            title="イベント 第4回",
+            description="VRChatイベント 第4回開催 参加方法はGroup Joinです。",
+        ),
+        event(
+            event_id="round-5",
+            source_id="round-post-5",
+            title="イベント 第5回",
+            description="VRChatイベント 第5回開催 参加方法はGroup Joinです。",
+        ),
+    ]
+
+    deduped, audit = deduplicate_events(rows)
+
+    assert len(deduped) == 2
+    assert audit["duplicate_occurrence_count"] == 0
+    assert audit["unresolved_ambiguous_cluster_count"] >= 1
+
+
+def test_dedup_is_idempotent_for_already_merged_occurrence():
+    original = [
+        event(
+            event_id="one",
+            source_id="post-one",
+            title="同一イベント告知",
+            description="VRChatで同一イベントを8/15 22:00から開催します。参加方法はGroup Joinです。",
+            organizer="@first",
+        ),
+        event(
+            event_id="two",
+            source_id="post-two",
+            title="同一イベント告知",
+            description="VRChatで同一イベントを8/15 22:00から開催します。参加方法はGroup Joinです。",
+            organizer="@second",
+        ),
+    ]
+
+    first, first_audit = deduplicate_events(original)
+    second, second_audit = deduplicate_events(first)
+
+    assert len(first) == len(second) == 1
+    assert first[0]["occurrence_id"] == second[0]["occurrence_id"]
+    assert second[0]["merged_source_count"] == 2
+    assert first_audit["duplicate_occurrence_count"] == 1
+    assert second_audit["duplicate_occurrence_count"] == 0


### PR DESCRIPTION
Closes #73
Closes #74
Closes #75
Closes #77

Relates to #76; production verification continues in a follow-up because the first post-merge production run exposed a registration-count authority mismatch.

## Goal
Prevent multiple X/Yahoo/source posts for one real-world VRChat event occurrence from appearing as duplicate public calendar rows.

## Contract
- keep source-record provenance intact;
- introduce canonical `occurrence_id` at the public snapshot boundary;
- merge only high-confidence same-occurrence candidates;
- keep ambiguous candidates separate and auditable;
- enforce `1 occurrence = 1 JSON row = 1 VEVENT` before publication;
- remove the obsolete no-op deduplicator so the authority is unambiguous.

## Regression fixtures
- 2026-08-15 `18ちゃん2周年記念イベント`: same text/start, different organizers/status IDs -> 1 occurrence / 2 provenance records.
- 2026-08-15 `０属オークション 第4回`: same organizer/start/ordinal, updated announcement text -> 1 occurrence / 2 provenance records.
- negative controls cover different dates, different organizers, and different ordinal numbers.

## Verification
Exact-head PR CI passed on Python 3.11/3.12/3.13. Post-merge production run #85 reached occurrence dedup successfully (`628 -> 623`, 5 collapsed) but failed the validation step because `registration-count-audit.json` still sourced `calendar_event_count` from pre-dedup `health.json`. Follow-up work will make the final public snapshot authoritative for this KPI and re-run production verification.