### PR TITLE
fix: count post-dedup occurrences in registration audit

### DIFF
--- a/scripts/build_registration_count_audit.py
+++ b/scripts/build_registration_count_audit.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 CALENDAR_HEALTH = Path("public/health.json")
+EVENTS = Path("public/events.json")
 YAHOO_HEALTH = Path("data/yahoo_realtime_health.json")
 OUTPUT = Path("public/registration-count-audit.json")
 KPI_LOG = Path("public/accepted-event-kpi.jsonl")
@@ -24,15 +25,22 @@ def integer(value: Any) -> int:
     return int(value)
 
 
-def snapshot(calendar: dict[str, Any], yahoo: dict[str, Any]) -> dict[str, Any]:
+def snapshot(
+    calendar: dict[str, Any], yahoo: dict[str, Any], events: dict[str, Any]
+) -> dict[str, Any]:
     sources = {
         str(row.get("name")): integer(row.get("count", 0))
         for row in calendar.get("sources", [])
         if isinstance(row, dict) and row.get("name")
     }
+    published_count = integer(events["count"])
+    rows = events.get("events")
+    if not isinstance(rows, list) or published_count != len(rows):
+        raise ValueError("public events count must match the events array")
     return {
-        "generated_at": str(calendar["generated_at"]),
-        "calendar_event_count": integer(calendar["event_count"]),
+        "generated_at": str(events.get("generated_at") or calendar["generated_at"]),
+        "calendar_event_count": published_count,
+        "normalized_event_count": integer(calendar["event_count"]),
         "source_counts": sources,
         "yahoo_candidate_count": integer(yahoo["history_candidate_count"]),
         "yahoo_accepted_count": integer(yahoo["history_accepted_count"]),
@@ -63,13 +71,16 @@ def delta(current: dict[str, Any], previous: dict[str, Any] | None) -> dict[str,
 
 def build() -> dict[str, Any]:
     calendar = read_json(CALENDAR_HEALTH, {})
+    events = read_json(EVENTS, {})
     yahoo = read_json(YAHOO_HEALTH, {})
     if calendar.get("status") != "ok":
         raise ValueError("calendar health must be ok")
     if yahoo.get("status") != "ok":
         raise ValueError("Yahoo health must be ok")
+    if not isinstance(events, dict) or "count" not in events:
+        raise ValueError("public events snapshot is required")
 
-    current = snapshot(calendar, yahoo)
+    current = snapshot(calendar, yahoo, events)
     existing = read_json(OUTPUT, {})
     snapshots = [row for row in existing.get("snapshots", []) if isinstance(row, dict)]
     snapshots = [row for row in snapshots if row.get("generated_at") != current["generated_at"]]

--- a/tests/test_registration_count_audit.py
+++ b/tests/test_registration_count_audit.py
@@ -5,8 +5,22 @@ import json
 from scripts import build_registration_count_audit as audit
 
 
+def write_events(path, *, generated_at: str, count: int) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "generated_at": generated_at,
+                "count": count,
+                "events": [{"id": f"event-{index}"} for index in range(count)],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_build_appends_snapshot_and_computes_deltas(tmp_path, monkeypatch):
     calendar = tmp_path / "health.json"
+    events = tmp_path / "events.json"
     yahoo = tmp_path / "yahoo.json"
     output = tmp_path / "audit.json"
     calendar.write_text(
@@ -23,6 +37,7 @@ def test_build_appends_snapshot_and_computes_deltas(tmp_path, monkeypatch):
         ),
         encoding="utf-8",
     )
+    write_events(events, generated_at="2026-08-05T00:00:00Z", count=610)
     yahoo.write_text(
         json.dumps(
             {
@@ -58,16 +73,61 @@ def test_build_appends_snapshot_and_computes_deltas(tmp_path, monkeypatch):
         encoding="utf-8",
     )
     monkeypatch.setattr(audit, "CALENDAR_HEALTH", calendar)
+    monkeypatch.setattr(audit, "EVENTS", events)
     monkeypatch.setattr(audit, "YAHOO_HEALTH", yahoo)
     monkeypatch.setattr(audit, "OUTPUT", output)
 
     payload = audit.build()
     latest = payload["latest"]
+    assert latest["calendar_event_count"] == 610
+    assert latest["normalized_event_count"] == 610
     assert latest["delta_from_previous"]["calendar_event_count"] == 10
     assert latest["delta_from_previous"]["yahoo_candidate_count"] == 70
     assert latest["delta_from_previous"]["yahoo_accepted_count"] == 4
     assert latest["delta_from_previous"]["yahoo_rejected_count"] == 66
     assert latest["delta_from_previous"]["source_counts"]["yahoo_realtime_events"] == 4
+
+
+def test_build_uses_post_dedup_public_count(tmp_path, monkeypatch):
+    calendar = tmp_path / "health.json"
+    events = tmp_path / "events.json"
+    yahoo = tmp_path / "yahoo.json"
+    output = tmp_path / "audit.json"
+    calendar.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-08-15T11:10:49Z",
+                "status": "ok",
+                "event_count": 628,
+                "sources": [{"name": "yahoo_realtime_events", "count": 706}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    write_events(events, generated_at="2026-08-15T11:10:49Z", count=623)
+    yahoo.write_text(
+        json.dumps(
+            {
+                "status": "ok",
+                "history_candidate_count": 4482,
+                "history_accepted_count": 706,
+                "history_rejected_count": 3776,
+                "queries_succeeded": 22,
+                "queries_failed": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    output.write_text(json.dumps({"snapshots": []}), encoding="utf-8")
+    monkeypatch.setattr(audit, "CALENDAR_HEALTH", calendar)
+    monkeypatch.setattr(audit, "EVENTS", events)
+    monkeypatch.setattr(audit, "YAHOO_HEALTH", yahoo)
+    monkeypatch.setattr(audit, "OUTPUT", output)
+
+    latest = audit.build()["latest"]
+
+    assert latest["calendar_event_count"] == 623
+    assert latest["normalized_event_count"] == 628
 
 
 def test_append_kpi_log_keeps_only_cumulative_accepted_event_kpi(tmp_path):
@@ -127,10 +187,13 @@ def test_append_kpi_log_rejects_cumulative_decrease(tmp_path):
 
 def test_build_rejects_unhealthy_inputs(tmp_path, monkeypatch):
     calendar = tmp_path / "health.json"
+    events = tmp_path / "events.json"
     yahoo = tmp_path / "yahoo.json"
     calendar.write_text(json.dumps({"status": "degraded"}), encoding="utf-8")
+    write_events(events, generated_at="2026-08-15T00:00:00Z", count=1)
     yahoo.write_text(json.dumps({"status": "ok"}), encoding="utf-8")
     monkeypatch.setattr(audit, "CALENDAR_HEALTH", calendar)
+    monkeypatch.setattr(audit, "EVENTS", events)
     monkeypatch.setattr(audit, "YAHOO_HEALTH", yahoo)
     try:
         audit.build()


### PR DESCRIPTION
Follow-up to #78 and #76.

Production run #85 successfully executed canonical occurrence dedup (`628 -> 623`, 5 source-post duplicates collapsed) but then failed validation because `registration-count-audit.json` still read `calendar_event_count=628` from pre-dedup `public/health.json`.

This patch makes the final `public/events.json` snapshot authoritative for `calendar_event_count` while retaining the upstream normalized count separately as `normalized_event_count`.

Acceptance:
- production registration audit reports final published occurrence count;
- upstream normalized count remains observable;
- fixture reproduces `628 normalized -> 623 published`;
- exact-head CI must pass before merge;
- after merge, production workflow must pass and commit the canonical generated snapshot.