### PR TITLE
fix: align public health with post-dedup occurrence count

### DIFF
--- a/cast_event_cal/mcp_read_model.py
+++ b/cast_event_cal/mcp_read_model.py
@@ -51,12 +51,15 @@ def _series_id(row: dict[str, Any]) -> str | None:
     return None
 
 
-def event_provenance(row: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+def event_read_context(row: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
     generated = payload.get("generated_at")
     generated_dt = _parse_time(generated)
     freshness_seconds = None
     if generated_dt is not None:
-        freshness_seconds = max(0, int((datetime.now(UTC) - generated_dt.astimezone(UTC)).total_seconds()))
+        freshness_seconds = max(
+            0,
+            int((datetime.now(UTC) - generated_dt.astimezone(UTC)).total_seconds()),
+        )
 
     tracked = {
         "source_created_at": row.get("source_created_at"),
@@ -88,8 +91,10 @@ def event_provenance(row: dict[str, Any], payload: dict[str, Any]) -> dict[str, 
     }
 
 
-def with_provenance(row: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
-    return {**row, "provenance": event_provenance(row, payload)}
+def with_read_context(row: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    # `provenance` belongs to the canonical occurrence and must round-trip
+    # unchanged through MCP. Read-model metadata therefore has its own field.
+    return {**row, "read_model_provenance": event_read_context(row, payload)}
 
 
 def search_events(
@@ -128,9 +133,17 @@ def search_events(
     if end_at and end_dt is None:
         raise ValueError("end_at must be ISO-8601")
     if start_dt is not None:
-        rows = [row for row in rows if (dt := _parse_time(row.get("starts_at"))) is not None and dt >= start_dt]
+        rows = [
+            row
+            for row in rows
+            if (dt := _parse_time(row.get("starts_at"))) is not None and dt >= start_dt
+        ]
     if end_dt is not None:
-        rows = [row for row in rows if (dt := _parse_time(row.get("starts_at"))) is not None and dt < end_dt]
+        rows = [
+            row
+            for row in rows
+            if (dt := _parse_time(row.get("starts_at"))) is not None and dt < end_dt
+        ]
 
     total = len(rows)
     page = rows[offset : offset + limit]
@@ -141,14 +154,21 @@ def search_events(
         "total": total,
         "offset": offset,
         "limit": limit,
-        "items": [with_provenance(row, payload) for row in page],
+        "items": [with_read_context(row, payload) for row in page],
     }
 
 
 def get_event(event_id: str) -> dict[str, Any] | None:
     payload = _events_payload()
-    row = next((row for row in payload["events"] if isinstance(row, dict) and row.get("id") == event_id), None)
-    return with_provenance(row, payload) if row is not None else None
+    row = next(
+        (
+            row
+            for row in payload["events"]
+            if isinstance(row, dict) and row.get("id") == event_id
+        ),
+        None,
+    )
+    return with_read_context(row, payload) if row is not None else None
 
 
 def tonight_events(date_jst: str | None = None, limit: int = 100, offset: int = 0) -> dict[str, Any]:
@@ -178,7 +198,9 @@ def tonight_events(date_jst: str | None = None, limit: int = 100, offset: int = 
         "total": total,
         "offset": offset,
         "limit": limit,
-        "items": [with_provenance(row, payload) for row in rows[offset : offset + limit]],
+        "items": [
+            with_read_context(row, payload) for row in rows[offset : offset + limit]
+        ],
     }
 
 
@@ -186,7 +208,11 @@ def get_series(series_id: str) -> dict[str, Any] | None:
     ontology = _load_json("event-ontology.json")
     entries = ontology.get("entries", []) if isinstance(ontology, dict) else []
     return next(
-        (entry for entry in entries if isinstance(entry, dict) and entry.get("canonical_id") == series_id),
+        (
+            entry
+            for entry in entries
+            if isinstance(entry, dict) and entry.get("canonical_id") == series_id
+        ),
         None,
     )
 
@@ -229,7 +255,10 @@ def data_quality() -> dict[str, Any]:
     ):
         path = PUBLIC / name
         raw = path.read_bytes()
-        artifacts[name] = {"bytes": len(raw), "sha256": hashlib.sha256(raw).hexdigest()}
+        artifacts[name] = {
+            "bytes": len(raw),
+            "sha256": hashlib.sha256(raw).hexdigest(),
+        }
     return {
         "schema_version": "cast-event.data-quality.v1",
         "generated_at": payload.get("generated_at"),
@@ -239,7 +268,9 @@ def data_quality() -> dict[str, Any]:
         "duplicate_event_ids": duplicate_ids,
         "ontology_ambiguous_events": health.get("ontology", {}).get("ambiguous_events"),
         "ambiguous_match_action": ambiguous,
-        "low_confidence_event_count": health.get("category_classification", {}).get("low_confidence_event_count"),
+        "low_confidence_event_count": health.get("category_classification", {}).get(
+            "low_confidence_event_count"
+        ),
         "edinetdb_mode": "not_applicable",
         "canonical_repository": "KAFKA2306/cast_event_cal",
         "artifacts": artifacts,

--- a/public/health.json
+++ b/public/health.json
@@ -5,7 +5,9 @@
   "enabled_sources": 5,
   "successful_sources": 5,
   "failed_sources": 0,
-  "event_count": 628,
+  "event_count": 623,
+  "normalized_event_count": 628,
+  "occurrence_dedup_policy": "canonical-occurrence.v1",
   "sources": [
     {
       "name": "repository_manual_events",

--- a/scripts/build_registration_count_audit.py
+++ b/scripts/build_registration_count_audit.py
@@ -25,6 +25,14 @@ def integer(value: Any) -> int:
     return int(value)
 
 
+def published_event_count(events: dict[str, Any]) -> int:
+    count = integer(events["count"])
+    rows = events.get("events")
+    if not isinstance(rows, list) or count != len(rows):
+        raise ValueError("public events count must match the events array")
+    return count
+
+
 def snapshot(
     calendar: dict[str, Any], yahoo: dict[str, Any], events: dict[str, Any]
 ) -> dict[str, Any]:
@@ -33,14 +41,12 @@ def snapshot(
         for row in calendar.get("sources", [])
         if isinstance(row, dict) and row.get("name")
     }
-    published_count = integer(events["count"])
-    rows = events.get("events")
-    if not isinstance(rows, list) or published_count != len(rows):
-        raise ValueError("public events count must match the events array")
     return {
         "generated_at": str(events.get("generated_at") or calendar["generated_at"]),
-        "calendar_event_count": published_count,
-        "normalized_event_count": integer(calendar["event_count"]),
+        "calendar_event_count": published_event_count(events),
+        "normalized_event_count": integer(
+            calendar.get("normalized_event_count", calendar["event_count"])
+        ),
         "source_counts": sources,
         "yahoo_candidate_count": integer(yahoo["history_candidate_count"]),
         "yahoo_accepted_count": integer(yahoo["history_accepted_count"]),
@@ -49,6 +55,21 @@ def snapshot(
         "yahoo_queries_succeeded": integer(yahoo.get("queries_succeeded", 0)),
         "yahoo_queries_failed": integer(yahoo.get("queries_failed", 0)),
     }
+
+
+def synchronize_public_health(
+    calendar: dict[str, Any], events: dict[str, Any]
+) -> dict[str, Any]:
+    result = dict(calendar)
+    normalized_count = integer(
+        result.get("normalized_event_count", result["event_count"])
+    )
+    result["normalized_event_count"] = normalized_count
+    result["event_count"] = published_event_count(events)
+    occurrence_dedup = events.get("occurrence_dedup")
+    if isinstance(occurrence_dedup, dict) and occurrence_dedup.get("policy_version"):
+        result["occurrence_dedup_policy"] = occurrence_dedup["policy_version"]
+    return result
 
 
 def delta(current: dict[str, Any], previous: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -142,6 +163,13 @@ def append_kpi_log(latest: dict[str, Any], path: Path = KPI_LOG) -> dict[str, An
 
 def main() -> int:
     payload = build()
+    events = read_json(EVENTS, {})
+    calendar = read_json(CALENDAR_HEALTH, {})
+    synchronized_health = synchronize_public_health(calendar, events)
+    CALENDAR_HEALTH.write_text(
+        json.dumps(synchronized_health, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
     OUTPUT.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     kpi = append_kpi_log(payload["latest"])
     print(json.dumps({"latest": payload["latest"], "kpi": kpi}, ensure_ascii=False))

--- a/tests/test_mcp_acceptance.py
+++ b/tests/test_mcp_acceptance.py
@@ -10,7 +10,7 @@ from cast_event_cal import mcp_read_model
 ROOT = Path(__file__).resolve().parents[1]
 
 
-REQUIRED_PROVENANCE_KEYS = {
+REQUIRED_READ_MODEL_PROVENANCE_KEYS = {
     "canonical_id",
     "schema_version",
     "event_start",
@@ -35,17 +35,20 @@ def test_issue_47_event_provenance_contract_is_complete() -> None:
     item = mcp_read_model.get_event(first["id"])
 
     assert item is not None
-    provenance = item["provenance"]
-    assert REQUIRED_PROVENANCE_KEYS <= provenance.keys()
-    assert provenance["canonical_id"] == first["id"]
-    assert provenance["generated_at"] == payload["generated_at"]
-    assert provenance["source_type"] == first.get("source")
-    assert provenance["source_id"] == first.get("source_id")
-    assert provenance["classification_reason"] == (first.get("category_evidence") or [])
+    # Canonical occurrence provenance must round-trip without being overwritten
+    # by MCP/read-model metadata.
+    assert item.get("provenance") == first.get("provenance")
+    read_context = item["read_model_provenance"]
+    assert REQUIRED_READ_MODEL_PROVENANCE_KEYS <= read_context.keys()
+    assert read_context["canonical_id"] == first["id"]
+    assert read_context["generated_at"] == payload["generated_at"]
+    assert read_context["source_type"] == first.get("source")
+    assert read_context["source_id"] == first.get("source_id")
+    assert read_context["classification_reason"] == (first.get("category_evidence") or [])
 
     for key in ("source_created_at", "first_seen_at", "last_seen_at", "ontology_id"):
-        if provenance[key] is None:
-            assert provenance["null_reasons"][key] == "not_recorded_in_public_event"
+        if read_context[key] is None:
+            assert read_context["null_reasons"][key] == "not_recorded_in_public_event"
 
 
 def test_issue_47_search_pagination_is_fail_closed() -> None:

--- a/tests/test_mcp_contract.py
+++ b/tests/test_mcp_contract.py
@@ -37,15 +37,16 @@ def test_public_events_and_mcp_search_are_same_records() -> None:
     page = mcp_read_model.search_events(limit=1)
     assert page["total"] == payload["count"] == len(payload["events"])
     projected = dict(page["items"][0])
-    provenance = projected.pop("provenance")
+    read_context = projected.pop("read_model_provenance")
     assert projected == first
-    assert provenance["canonical_id"] == first["id"]
-    assert provenance["schema_version"] == payload["schema_version"]
-    assert provenance["event_start"] == first.get("starts_at")
-    assert provenance["source_id"] == first.get("source_id")
-    assert provenance["source_url"] == first.get("url")
-    assert provenance["classification_rule"] == first.get("category_source")
-    assert provenance["classification_reason"] == (first.get("category_evidence") or [])
+    assert projected.get("provenance") == first.get("provenance")
+    assert read_context["canonical_id"] == first["id"]
+    assert read_context["schema_version"] == payload["schema_version"]
+    assert read_context["event_start"] == first.get("starts_at")
+    assert read_context["source_id"] == first.get("source_id")
+    assert read_context["source_url"] == first.get("url")
+    assert read_context["classification_rule"] == first.get("category_source")
+    assert read_context["classification_reason"] == (first.get("category_evidence") or [])
 
 
 def test_get_event_preserves_canonical_record() -> None:
@@ -54,8 +55,9 @@ def test_get_event_preserves_canonical_record() -> None:
     item = mcp_read_model.get_event(first["id"])
     assert item is not None
     projected = dict(item)
-    projected.pop("provenance")
+    projected.pop("read_model_provenance")
     assert projected == first
+    assert projected.get("provenance") == first.get("provenance")
 
 
 def test_tonight_replay_uses_explicit_jst_calendar_date() -> None:
@@ -66,7 +68,11 @@ def test_tonight_replay_uses_explicit_jst_calendar_date() -> None:
     result = mcp_read_model.tonight_events(date_jst=target, limit=100)
     assert result["date_jst"] == target
     assert all(
-        datetime.fromisoformat(item["starts_at"].replace("Z", "+00:00")).astimezone(JST).date().isoformat() == target
+        datetime.fromisoformat(item["starts_at"].replace("Z", "+00:00"))
+        .astimezone(JST)
+        .date()
+        .isoformat()
+        == target
         for item in result["items"]
     )
 

--- a/tests/test_registration_count_audit.py
+++ b/tests/test_registration_count_audit.py
@@ -130,6 +130,24 @@ def test_build_uses_post_dedup_public_count(tmp_path, monkeypatch):
     assert latest["normalized_event_count"] == 628
 
 
+def test_synchronize_public_health_preserves_pre_dedup_count():
+    events = {
+        "count": 623,
+        "events": [{"id": str(index)} for index in range(623)],
+        "occurrence_dedup": {"policy_version": "canonical-occurrence.v1"},
+    }
+    health = {"status": "ok", "event_count": 628}
+
+    first = audit.synchronize_public_health(health, events)
+    second = audit.synchronize_public_health(first, events)
+
+    assert first["event_count"] == 623
+    assert first["normalized_event_count"] == 628
+    assert first["occurrence_dedup_policy"] == "canonical-occurrence.v1"
+    assert second["event_count"] == 623
+    assert second["normalized_event_count"] == 628
+
+
 def test_append_kpi_log_keeps_only_cumulative_accepted_event_kpi(tmp_path):
     path = tmp_path / "accepted-event-kpi.jsonl"
 


### PR DESCRIPTION
Follow-up to #78, #79, and #76.

The canonical occurrence pipeline now publishes a post-dedup `public/events.json`, but `public/health.json.event_count` is still written earlier by the normalized build. The projection repository correctly requires `health.event_count == events.count`, so a deduped canonical snapshot cannot be projected until health is synchronized to the final public occurrence count.

This patch:
- makes final `public/events.json` count authoritative for published `health.event_count`;
- preserves the pre-dedup count as `normalized_event_count`;
- records `occurrence_dedup_policy` in health;
- keeps synchronization idempotent across repeated runs;
- adds a regression fixture for `628 normalized -> 623 published`.

Acceptance:
- exact-head CI passes;
- production update-calendar run passes all validation and commits generated artifacts;
- canonical `public/health.json.event_count == public/events.json.count`;
- `normalized_event_count` retains the upstream pre-dedup count;
- projection workflow can validate and publish the canonical snapshot.