### PR TITLE
docs: keep quick start on the canonical CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,11 @@ matchは単なるfuzzy searchでは成立しません。alias exact match、ま�
 python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -e '.[dev]'
-ruff check cast_event_cal scripts tests main_executor.py
-pytest tests
+ruff check cast_event_cal scripts tests
+pytest
+cast-event-cal validate
 python scripts/materialize_events.py
-python main_executor.py run --strict
+cast-event-cal run --strict
 python scripts/render_frontend.py
 python -m http.server 8000 --directory public
 ```


### PR DESCRIPTION
Follow-up to #82. The README still referenced the deleted `main_executor.py` wrapper.

This aligns the quick start with the verified execution surface:
- `ruff check cast_event_cal scripts tests`
- `pytest`
- `cast-event-cal validate`
- `cast-event-cal run --strict`

No runtime behavior changes; this removes a stale operator path so documentation matches CI and production.