### PR TITLE
refactor: make frontend renderer single-authority

### DIFF
--- a/cast_event_cal/core.py
+++ b/cast_event_cal/core.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import html
 import json
 import logging
 import os
@@ -439,27 +438,6 @@ def render_ics(events: Iterable[Event], generated_at: datetime) -> str:
     return "\r\n".join(fold_ics(line) for line in lines) + "\r\n"
 
 
-def render_index(generated_at: str) -> str:
-    return f"""<!doctype html>
-<html lang=\"ja\">
-<head>
-<meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">
-<meta name=\"description\" content=\"VRChatイベントを複数の公開情報源から自動集約するカレンダー\">
-<title>VRChat Event Calendar</title>
-<style>
-:root{{--bg:#fbfaf7;--ink:#243653;--blue:#8fb5ec;--lav:#b9a8e6;--rose:#efb4c1;--mint:#b7dbc8;--apricot:#f3cfaa;--card:#fff;--shadow:0 18px 50px rgba(76,91,125,.09)}}
-*{{box-sizing:border-box}}body{{margin:0;background:radial-gradient(circle at 8% 0%,#eef5ff,transparent 34%),var(--bg);color:var(--ink);font-family:Inter,ui-sans-serif,system-ui,-apple-system,\"Noto Sans JP\",sans-serif}}main{{max-width:1120px;margin:auto;padding:44px 20px 72px}}header{{display:grid;gap:14px;margin-bottom:28px}}h1{{font-size:clamp(2rem,5vw,4.6rem);line-height:.95;letter-spacing:-.05em;margin:0;max-width:850px}}.lede{{font-size:1.08rem;max-width:760px;line-height:1.8}}.toolbar{{display:flex;flex-wrap:wrap;gap:10px;align-items:center}}input,select,a.button{{border:1px solid #dbe3ef;border-radius:999px;background:#fff;color:var(--ink);padding:12px 16px;font:inherit;text-decoration:none}}input{{min-width:260px;flex:1}}.status{{font-size:.9rem;opacity:.72}}.grid{{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px;margin-top:24px}}article{{background:var(--card);border:1px solid rgba(143,181,236,.34);border-radius:22px;padding:20px;box-shadow:var(--shadow);display:grid;gap:11px}}article.review{{border-color:var(--apricot)}}article.cancelled{{opacity:.6}}.date{{font-weight:750;color:#516b93}}h2{{font-size:1.15rem;line-height:1.45;margin:0}}.meta{{font-size:.92rem;line-height:1.55}}.tags{{display:flex;gap:6px;flex-wrap:wrap}}.tag{{font-size:.78rem;padding:4px 9px;background:#f2f5fa;border-radius:999px}}.empty{{padding:40px;border:1px dashed #b9c7dc;border-radius:22px;text-align:center}}footer{{margin-top:42px;font-size:.86rem;opacity:.7}}
-</style>
-</head>
-<body><main><header><div class=\"status\">AUTOMATED / SOURCE-TRACEABLE / JST</div><h1>VRChat Event Calendar</h1><p class=\"lede\">公開JSON・ICS、VRChat Group Calendar、X APIから取得したイベントを、出典と時刻を保持したまま統合します。曖昧な日時は推測せず除外または要確認にします。</p><div class=\"toolbar\"><input id=\"q\" type=\"search\" placeholder=\"イベント、主催者、会場を検索\"><select id=\"range\"><option value=\"all\">すべて</option><option value=\"today\">今日</option><option value=\"week\">7日以内</option><option value=\"month\">30日以内</option></select><a class=\"button\" href=\"calendar.ics\">カレンダーを購読</a></div><div id=\"health\" class=\"status\">データ読込中</div></header><section id=\"events\" class=\"grid\"></section><footer>Generated: {html.escape(generated_at)} · <a href=\"events.json\">JSON API</a> · <a href=\"health.json\">取得状態</a> · <a href=\"https://github.com/KAFKA2306/cast_event_cal\">GitHub</a></footer></main>
-<script>
-const state={{events:[],health:null}};const esc=s=>String(s??'').replace(/[&<>\"']/g,c=>({{'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;',\"'\":'&#39;'}}[c]));
-const fmt=iso=>new Intl.DateTimeFormat('ja-JP',{{timeZone:'Asia/Tokyo',month:'short',day:'numeric',weekday:'short',hour:'2-digit',minute:'2-digit'}}).format(new Date(iso));
-function render(){{const q=document.querySelector('#q').value.toLowerCase();const range=document.querySelector('#range').value;const now=new Date();const end=new Date(now);end.setDate(end.getDate()+(range==='today'?1:range==='week'?7:range==='month'?30:36500));const rows=state.events.filter(e=>{{const hay=[e.title,e.organizer,e.location,e.description,(e.tags||[]).join(' ')].join(' ').toLowerCase();return hay.includes(q)&&(range==='all'||(new Date(e.starts_at)>=now&&new Date(e.starts_at)<=end));}});document.querySelector('#events').innerHTML=rows.length?rows.map(e=>`<article class=\"${{e.review_required?'review ':''}}${{e.status==='cancelled'?'cancelled':''}}\"><div class=\"date\">${{fmt(e.starts_at)}}</div><h2>${{esc(e.title)}}</h2><div class=\"meta\">${{e.organizer?'主催: '+esc(e.organizer)+'<br>':''}}${{e.location?'会場: '+esc(e.location)+'<br>':''}}出典: ${{esc(e.source)}}</div><div class=\"tags\">${{(e.tags||[]).map(t=>`<span class=\"tag\">${{esc(t)}}</span>`).join('')}}</div>${{e.url?`<a href=\"${{esc(e.url)}}\" target=\"_blank\" rel=\"noopener\">告知を見る →</a>`:''}}</article>`).join(''):'<div class=\"empty\">条件に合うイベントはありません。</div>';}}
-Promise.all([fetch('events.json').then(r=>r.json()),fetch('health.json').then(r=>r.json())]).then(([data,health])=>{{state.events=data.events||[];state.health=health;document.querySelector('#health').textContent=`${{state.events.length}}件 · ${{health.status}} · 最終更新 ${{fmt(health.generated_at)}}`;render();}}).catch(()=>document.querySelector('#health').textContent='データを読み込めませんでした');document.querySelector('#q').addEventListener('input',render);document.querySelector('#range').addEventListener('change',render);
-</script></body></html>"""
-
-
 def write_outputs(events: list[Event], health: dict[str, Any], output_dir: Path, generated_at: datetime) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -472,7 +450,6 @@ def write_outputs(events: list[Event], health: dict[str, Any], output_dir: Path,
     (output_dir / "events.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     (output_dir / "calendar.ics").write_text(render_ics(events, generated_at), encoding="utf-8", newline="")
     (output_dir / "health.json").write_text(json.dumps(health, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    (output_dir / "index.html").write_text(render_index(payload["generated_at"]), encoding="utf-8")
     (output_dir / ".nojekyll").write_text("", encoding="utf-8")
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-from cast_event_cal.core import Event, deduplicate, parse_ics, render_ics, x_post_to_event
+from cast_event_cal.core import Event, deduplicate, parse_ics, render_ics, write_outputs, x_post_to_event
 
 
 def test_parse_ics_timezone_and_render_roundtrip():
@@ -30,3 +30,11 @@ def test_x_parser_rejects_ambiguous_post_and_accepts_explicit_datetime():
     assert event is not None
     assert event.starts_at == "2026-08-03T12:30:00Z"
     assert event.organizer == "@host"
+
+
+def test_core_outputs_leave_html_to_canonical_frontend_renderer(tmp_path):
+    generated_at = datetime(2026, 8, 16, tzinfo=UTC)
+    write_outputs([], {"status": "ok", "generated_at": "2026-08-16T00:00:00Z"}, tmp_path, generated_at)
+
+    assert {path.name for path in tmp_path.iterdir()} == {"events.json", "calendar.ics", "health.json", ".nojekyll"}
+    assert not (tmp_path / "index.html").exists()


### PR DESCRIPTION
Closes #83.

## Change
- remove the legacy inline HTML/CSS/JS `render_index()` from `cast_event_cal/core.py`
- stop `write_outputs()` from writing the intermediate `public/index.html`
- keep JSON / ICS / health / `.nojekyll` normalized outputs unchanged
- add a regression test that asserts core output never owns `index.html`

The canonical frontend remains `web/index.template.html` + `scripts/render_frontend.py`, which is already the documented production/Quick Start path.

## Complexity delta
- `cast_event_cal/core.py`: 572 -> 549 LOC (-23)
- changed files: 2
- source additions/deletions: +0 / -23
- test additions/deletions: +9 / -1
- total net LOC: -15
- dependencies: 3 -> 3
- project CLI commands: 2 -> 2
- workflow files: 9 -> 9
- frontend HTML authorities: 2 -> 1
- capabilities removed: 0 (the deleted HTML was overwritten by the canonical renderer in the owning workflow)

## Verification contract
Exact-head CI must pass. The new test directly verifies the responsibility boundary; existing frontend/rendering tests remain unchanged. No merge until the PR head is verified.