### PR TITLE
fix: serialize search pages after calendar refresh

### DIFF
--- a/.github/workflows/render-search-pages.yml
+++ b/.github/workflows/render-search-pages.yml
@@ -7,12 +7,6 @@ on:
       - scripts/render_search_pages.py
       - tests/test_search_pages.py
       - .github/workflows/render-search-pages.yml
-  push:
-    branches: [main]
-    paths:
-      - scripts/render_search_pages.py
-      - tests/test_search_pages.py
-      - .github/workflows/render-search-pages.yml
   workflow_run:
     workflows: ["Update calendar data"]
     types: [completed]


### PR DESCRIPTION
The first production run exposed a real race: the new search renderer and the existing `Update calendar data` workflow both started on the same main push and could write `public/` concurrently.

This removes the search workflow's main `push` trigger. Search rendering remains available for:
- PR verification
- `workflow_dispatch`
- `workflow_run` after successful `Update calendar data`

That makes the canonical order deterministic:

`Update calendar data → commit canonical public snapshot → Render searchable event pages → commit derived search surface`

No collection/classification logic changes.