### PR TITLE
feat: deploy canonical public snapshot to Cloudflare Workers

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "name": "cast-event-cal",
+  "compatibility_date": "2026-08-16",
+  "assets": {
+    "directory": "./public",
+    "html_handling": "auto-trailing-slash"
+  }
+}


### PR DESCRIPTION
## Goal

Deploy the canonical `public/` snapshot to the existing Cloudflare Worker `cast-event-cal` using Workers Static Assets, without changing canonical event generation or the existing GitHub Pages deployment.

Related: KAFKA2306/vrc_cast_event_calender#50

## Change

- add minimal `wrangler.jsonc`
- keep the existing Worker name `cast-event-cal`
- serve `./public` as static assets
- preserve folder-index canonical routing with `auto-trailing-slash`
- no Worker runtime code, bindings, alternate data pipeline, or build step

## Verification

- Cloudflare's current Static Assets documentation supports assets-only Workers without a `main` script
- `auto-trailing-slash` maps `events/<id>/index.html` to `/events/<id>/`
- Cloudflare Workers Builds can keep build command empty and use `npx wrangler deploy`

## Production contract

GitHub Pages remains untouched until Cloudflare asset parity and performance are measured under delivery issue #50.