### PR TITLE
feat: publish category landing pages for search growth

### DIFF
--- a/.github/workflows/render-search-pages.yml
+++ b/.github/workflows/render-search-pages.yml
@@ -5,7 +5,10 @@ on:
   pull_request:
     paths:
       - scripts/render_search_pages.py
+      - scripts/render_category_pages.py
       - tests/test_search_pages.py
+      - tests/test_category_pages.py
+      - public/category-ontology.json
       - .github/workflows/render-search-pages.yml
   workflow_run:
     workflows: ["Update calendar data"]
@@ -31,7 +34,7 @@ jobs:
           python-version: '3.12'
           cache: pip
       - run: pip install -e '.[dev]'
-      - run: pytest tests/test_search_pages.py -q
+      - run: pytest tests/test_search_pages.py tests/test_category_pages.py -q
 
   publish:
     if: github.event_name != 'pull_request' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
@@ -51,6 +54,8 @@ jobs:
           python-version: '3.12'
       - name: Render current/future crawlable event pages
         run: python scripts/render_search_pages.py
+      - name: Render category landing pages
+        run: python scripts/render_category_pages.py
       - name: Verify real public snapshot
         run: |
           python - <<'PY'
@@ -59,26 +64,37 @@ jobs:
           from pathlib import Path
 
           events = json.loads(Path('public/events.json').read_text(encoding='utf-8'))
-          pages = sorted(Path('public/events').glob('*/index.html'))
+          event_pages = sorted(Path('public/events').glob('*/index.html'))
+          category_pages = sorted(Path('public/categories').glob('*/index.html'))
           sitemap = ET.parse('public/sitemap.xml').getroot()
           ns = {'s': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
           urls = [node.text for node in sitemap.findall('s:url/s:loc', ns)]
           assert events['count'] == len(events['events'])
-          assert pages
-          assert len(urls) == len(pages) + 1
+          assert event_pages
+          assert category_pages
+          assert len(urls) == len(event_pages) + len(category_pages) + 1
           assert len(urls) == len(set(urls))
           assert urls[0] == 'https://kafka2306.github.io/vrc_cast_event_calender/'
-          assert all('application/ld+json' not in page.read_text(encoding='utf-8') for page in pages)
+          assert all('application/ld+json' not in page.read_text(encoding='utf-8') for page in event_pages)
+          for page in category_pages:
+              text = page.read_text(encoding='utf-8')
+              assert 'rel="canonical"' in text
+              assert '../../events/' in text
           index = Path('public/index.html').read_text(encoding='utf-8')
           assert 'searchable-events:start' in index
           assert 'analytics.js' in index
+          print(json.dumps({
+              'event_pages': len(event_pages),
+              'category_pages': len(category_pages),
+              'sitemap_urls': len(urls),
+          }, sort_keys=True))
           PY
       - name: Commit generated search surface
         run: |
           set -euo pipefail
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add public/index.html public/events public/sitemap.xml public/analytics.js public/analytics-config.json
+          git add public/index.html public/events public/categories public/sitemap.xml public/analytics.js public/analytics-config.json
           if git diff --cached --quiet; then
             echo 'Search surface is already current'
           else

--- a/scripts/render_category_pages.py
+++ b/scripts/render_category_pages.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import shutil
+from collections import Counter, defaultdict
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from scripts.render_search_pages import BASE_URL, SAFE_ID, event_title, format_jst, indexable, parse_time
+
+
+KIND_LABELS = {
+    "registration": "応募・登録",
+    "entry": "応募・登録",
+    "participation": "参加方法",
+    "join": "参加方法",
+    "group": "グループ",
+    "announcement": "公式告知",
+    "official": "公式情報",
+}
+
+
+def esc(value: object) -> str:
+    return html.escape(str(value or ""), quote=True)
+
+
+def action_kind_label(value: object) -> str:
+    kind = str(value or "official").lower()
+    for token, label in KIND_LABELS.items():
+        if token in kind:
+            return label
+    return "公式情報"
+
+
+def category_title(label: str) -> str:
+    return f"VRChat {label}イベント一覧 | VRChatイベントカレンダー"
+
+
+def render_category_page(
+    category_id: str,
+    label: str,
+    events: list[dict[str, object]],
+    base_url: str,
+) -> str:
+    canonical = f"{base_url}/categories/{category_id}/"
+    count = len(events)
+    description = f"現在・今後開催予定のVRChat {label}イベントを{count}件掲載。開催日時と公式・参加情報を確認できます。"
+    kinds = Counter(action_kind_label(event.get("primary_action_kind")) for event in events)
+    kind_summary = "、".join(f"{name} {value}件" for name, value in kinds.most_common())
+    items = "".join(
+        '<li><a href="../../events/{id}/" data-track="event_detail_open" data-event-id="{id}" '
+        'data-category="{category}">{title}</a><span>{date}</span></li>'.format(
+            id=esc(event["id"]),
+            category=esc(category_id),
+            title=esc(event_title(event)),
+            date=esc(format_jst(event.get("starts_at"))),
+        )
+        for event in events
+    )
+    return f'''<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{esc(category_title(label))}</title>
+<meta name="description" content="{esc(description)}">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<link rel="canonical" href="{esc(canonical)}">
+<meta property="og:type" content="website">
+<meta property="og:locale" content="ja_JP">
+<meta property="og:site_name" content="VRChatイベントカレンダー">
+<meta property="og:title" content="{esc(category_title(label))}">
+<meta property="og:description" content="{esc(description)}">
+<meta property="og:url" content="{esc(canonical)}">
+<meta name="twitter:card" content="summary">
+<style>
+:root{{--bg:#fbfaf7;--surface:#fff;--ink:#243653;--muted:#66758d;--line:#dfe6ef}}*{{box-sizing:border-box}}body{{margin:0;background:var(--bg);color:var(--ink);font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Noto Sans JP",sans-serif}}main{{width:min(900px,100%);margin:auto;padding:28px 18px 64px}}a{{color:inherit}}nav{{display:flex;gap:14px;flex-wrap:wrap;margin-bottom:28px}}nav a{{font-weight:700}}.eyebrow{{font-size:.78rem;font-weight:800;letter-spacing:.1em;color:#58729a}}h1{{font-size:clamp(1.9rem,6vw,3.4rem);line-height:1.08;letter-spacing:-.035em;margin:.5rem 0 1rem}}.summary{{line-height:1.8;color:var(--muted)}}.facts{{display:flex;gap:10px;flex-wrap:wrap;margin:20px 0}}.fact{{padding:10px 14px;border:1px solid var(--line);border-radius:999px;background:var(--surface)}}ul{{list-style:none;padding:0;margin:30px 0 0}}li{{display:flex;justify-content:space-between;gap:18px;padding:16px 0;border-top:1px solid var(--line)}}li a{{font-weight:800}}li span{{color:var(--muted);white-space:nowrap}}@media(max-width:620px){{li{{display:grid;gap:5px}}li span{{white-space:normal}}}}
+</style>
+<script src="../../analytics.js" data-config="../../analytics-config.json" defer></script>
+</head>
+<body data-page-kind="category-landing" data-category="{esc(category_id)}">
+<main>
+<nav><a href="../../">イベント一覧へ戻る</a><a href="../../calendar.ics" data-track="calendar_download">カレンダーを購読</a></nav>
+<div class="eyebrow">VRCHAT EVENT CATEGORY</div>
+<h1>{esc(label)}</h1>
+<p class="summary">{esc(description)}</p>
+<div class="facts"><span class="fact">掲載 {count}件</span><span class="fact">参加情報: {esc(kind_summary)}</span></div>
+<ul>{items}</ul>
+</main>
+</body>
+</html>
+'''
+
+
+def render(
+    events_path: Path,
+    ontology_path: Path,
+    public_root: Path,
+    base_url: str = BASE_URL,
+) -> dict[str, int]:
+    payload = json.loads(events_path.read_text(encoding="utf-8"))
+    generated_at = parse_time(payload.get("generated_at"))
+    if generated_at is None:
+        raise ValueError("events.json generated_at is missing or invalid")
+    rows = payload.get("events")
+    if not isinstance(rows, list):
+        raise ValueError("events.json events must be a list")
+
+    ontology = json.loads(ontology_path.read_text(encoding="utf-8"))
+    categories = ontology.get("categories")
+    if not isinstance(categories, list):
+        raise ValueError("category ontology categories must be a list")
+
+    labels: dict[str, str] = {}
+    for row in categories:
+        if not isinstance(row, dict):
+            continue
+        category_id = str(row.get("id") or "")
+        if category_id == "other" or not SAFE_ID.fullmatch(category_id):
+            continue
+        if int(row.get("priority") or 0) <= 0:
+            continue
+        label = str(row.get("label") or "").strip()
+        if label:
+            labels[category_id] = label
+
+    grouped: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in rows:
+        if not isinstance(row, dict) or not indexable(row, generated_at):
+            continue
+        category_id = str(row.get("category") or "")
+        if category_id in labels:
+            grouped[category_id].append(row)
+
+    for events in grouped.values():
+        events.sort(key=lambda row: (parse_time(row.get("starts_at")) or generated_at, str(row.get("id"))))
+
+    categories_root = public_root / "categories"
+    shutil.rmtree(categories_root, ignore_errors=True)
+    categories_root.mkdir(parents=True, exist_ok=True)
+
+    generated_ids = sorted(category_id for category_id, events in grouped.items() if events)
+    for category_id in generated_ids:
+        target = categories_root / category_id
+        target.mkdir()
+        (target / "index.html").write_text(
+            render_category_page(category_id, labels[category_id], grouped[category_id], base_url),
+            encoding="utf-8",
+        )
+
+    sitemap_path = public_root / "sitemap.xml"
+    tree = ET.parse(sitemap_path)
+    root = tree.getroot()
+    namespace = "{http://www.sitemaps.org/schemas/sitemap/0.9}"
+    existing = [node.text or "" for node in root.findall(f"{namespace}url/{namespace}loc")]
+    category_urls = [f"{base_url}/categories/{category_id}/" for category_id in generated_ids]
+    if any("/categories/" in url for url in existing):
+        raise ValueError("category URLs already present before category render")
+    lastmod = generated_at.isoformat().replace("+00:00", "Z")
+    for url in category_urls:
+        node = ET.SubElement(root, f"{namespace}url")
+        ET.SubElement(node, f"{namespace}loc").text = url
+        ET.SubElement(node, f"{namespace}lastmod").text = lastmod
+    ET.register_namespace("", "http://www.sitemaps.org/schemas/sitemap/0.9")
+    tree.write(sitemap_path, encoding="utf-8", xml_declaration=True)
+
+    return {
+        "category_count": len(generated_ids),
+        "category_event_links": sum(len(grouped[category_id]) for category_id in generated_ids),
+        "sitemap_url_count": len(existing) + len(category_urls),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--events", type=Path, default=Path("public/events.json"))
+    parser.add_argument("--ontology", type=Path, default=Path("public/category-ontology.json"))
+    parser.add_argument("--public-root", type=Path, default=Path("public"))
+    parser.add_argument("--base-url", default=BASE_URL)
+    args = parser.parse_args()
+    result = render(args.events, args.ontology, args.public_root, args.base_url.rstrip("/"))
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_category_pages.py
+++ b/tests/test_category_pages.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.render_category_pages import render as render_categories
+from scripts.render_search_pages import render as render_events
+
+
+def _root(tmp_path: Path) -> Path:
+    (tmp_path / "index.html").write_text(
+        '<!doctype html><html><head><style>:root{--line:#ddd;--radius:20px;--muted:#666}.eyebrow{}</style></head>'
+        '<body><a class="button" href="calendar.ics">カレンダーを購読</a><footer>footer</footer></body></html>',
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_category_pages_use_only_indexable_observed_events(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    payload = {
+        "generated_at": "2026-08-16T00:00:00Z",
+        "events": [
+            {
+                "id": "music-1",
+                "title": "音楽イベント",
+                "starts_at": "2026-08-17T12:00:00Z",
+                "category": "music",
+                "primary_action_url": "https://example.com/music",
+                "primary_action_kind": "announcement",
+            },
+            {
+                "id": "community-1",
+                "title": "交流イベント",
+                "starts_at": "2026-08-18T12:00:00Z",
+                "category": "community",
+                "primary_action_url": "https://example.com/community",
+                "primary_action_kind": "join_group",
+            },
+            {
+                "id": "other-1",
+                "title": "その他",
+                "starts_at": "2026-08-19T12:00:00Z",
+                "category": "other",
+                "primary_action_url": "https://example.com/other",
+            },
+            {
+                "id": "review-1",
+                "title": "要レビュー",
+                "starts_at": "2026-08-20T12:00:00Z",
+                "category": "music",
+                "review_required": True,
+                "primary_action_url": "https://example.com/review",
+            },
+        ],
+    }
+    ontology = {
+        "categories": [
+            {"id": "music", "label": "音楽・ダンス", "priority": 90},
+            {"id": "community", "label": "交流・カフェ", "priority": 60},
+            {"id": "art", "label": "アート・展示・撮影", "priority": 95},
+            {"id": "other", "label": "その他", "priority": 0},
+        ]
+    }
+    events_path = root / "events.json"
+    ontology_path = root / "category-ontology.json"
+    events_path.write_text(json.dumps(payload), encoding="utf-8")
+    ontology_path.write_text(json.dumps(ontology), encoding="utf-8")
+
+    render_events(events_path, root, "https://example.test/project")
+    result = render_categories(events_path, ontology_path, root, "https://example.test/project")
+
+    assert result == {"category_count": 2, "category_event_links": 2, "sitemap_url_count": 6}
+    music = (root / "categories/music/index.html").read_text(encoding="utf-8")
+    community = (root / "categories/community/index.html").read_text(encoding="utf-8")
+    assert "VRChat 音楽・ダンスイベント一覧" in music
+    assert 'rel="canonical" href="https://example.test/project/categories/music/"' in music
+    assert 'href="../../events/music-1/"' in music
+    assert "要レビュー" not in music
+    assert "参加情報: 公式告知 1件" in music
+    assert 'href="../../events/community-1/"' in community
+    assert "参加情報: 参加方法 1件" in community
+    assert not (root / "categories/art").exists()
+    assert not (root / "categories/other").exists()
+
+    sitemap = (root / "sitemap.xml").read_text(encoding="utf-8")
+    assert "https://example.test/project/categories/music/" in sitemap
+    assert "https://example.test/project/categories/community/" in sitemap
+    assert "/categories/art/" not in sitemap
+    assert "/categories/other/" not in sitemap


### PR DESCRIPTION
## Goal

Implement #92 by generating indexable category landing pages from the existing category ontology and current/future canonical events.

## Change

- add `scripts/render_category_pages.py`
- generate `/categories/<id>/` only for ontology categories with priority > 0 and at least one indexable current/future event
- exclude `other`, empty categories, review-required events, and stale events
- include unique title / description / canonical / OGP
- include deterministic event links and participation-information mix from existing fields only
- append only generated category URLs to the existing sitemap
- add focused tests and production parity checks

## Contract

No LLM-authored filler, no keyword-combination pages, no alternate event database, and no change to event acceptance semantics.

Closes #92