### PR TITLE
fix: publish search surface after generator changes

### DIFF
--- a/.github/workflows/render-search-pages.yml
+++ b/.github/workflows/render-search-pages.yml
@@ -2,6 +2,15 @@ name: Render searchable event pages
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - scripts/render_search_pages.py
+      - scripts/render_category_pages.py
+      - tests/test_search_pages.py
+      - tests/test_category_pages.py
+      - public/category-ontology.json
+      - .github/workflows/render-search-pages.yml
   pull_request:
     paths:
       - scripts/render_search_pages.py


### PR DESCRIPTION
## Goal

Make search-surface code changes publish immediately without reintroducing the prior race with calendar refreshes.

## Change

Add a narrow `push` trigger on `main` only for search generator/test/ontology/workflow files. Generated `public/**` commits do not match this trigger, so there is no publish loop. Calendar-data updates continue to use the serialized `workflow_run` path.

Related: #92