### PR TITLE
fix: make category renderer executable in Actions

### DIFF
--- a/.github/workflows/render-search-pages.yml
+++ b/.github/workflows/render-search-pages.yml
@@ -44,6 +44,8 @@ jobs:
           cache: pip
       - run: pip install -e '.[dev]'
       - run: pytest tests/test_search_pages.py tests/test_category_pages.py -q
+      - run: python scripts/render_search_pages.py
+      - run: python scripts/render_category_pages.py
 
   publish:
     if: github.event_name != 'pull_request' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')

--- a/scripts/render_category_pages.py
+++ b/scripts/render_category_pages.py
@@ -8,7 +8,10 @@ from collections import Counter, defaultdict
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
-from scripts.render_search_pages import BASE_URL, SAFE_ID, event_title, format_jst, indexable, parse_time
+try:
+    from scripts.render_search_pages import BASE_URL, SAFE_ID, event_title, format_jst, indexable, parse_time
+except ModuleNotFoundError:
+    from render_search_pages import BASE_URL, SAFE_ID, event_title, format_jst, indexable, parse_time
 
 
 KIND_LABELS = {


### PR DESCRIPTION
## Goal

Repair the #92 production publish failure without changing category semantics.

## Cause

`pytest` imports `scripts.render_category_pages` as a module, but Actions executes `python scripts/render_category_pages.py`. In direct execution, `scripts` is not importable as a package from `sys.path[0]`, causing `ModuleNotFoundError`.

## Change

Support both module import and direct script execution with a two-path import fallback.

## Evidence

Failed production publish: Actions run `31940087489`, category render step only.

Related: #92