### PR TITLE
fix: serialize calendar and search public writers

### DIFF
--- a/.github/workflows/render-search-pages.yml
+++ b/.github/workflows/render-search-pages.yml
@@ -28,7 +28,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: searchable-event-pages
+  group: cast-event-calendar-production
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Goal

Prevent concurrent canonical workflows from editing and committing `public/index.html` at the same time.

## Evidence

`Update calendar data` run `31940674052` completed collection, enrichment, frontend rendering, ontology, and validation successfully, then failed only at the final rebase because search publish had concurrently committed `public/index.html`:

`CONFLICT (content): Merge conflict in public/index.html`

## Change

Use the existing `cast-event-calendar-production` concurrency group for `Render searchable event pages` as well. Both public writers now serialize with `cancel-in-progress: false`.

No data or rendering semantics change.