### PR TITLE
fix: keep sitemap lastmod truthful

### DIFF
--- a/scripts/render_search_pages.py
+++ b/scripts/render_search_pages.py
@@ -217,12 +217,11 @@ def render_event_page(event: dict[str, object], base_url: str) -> str:
 '''
 
 
-def sitemap_xml(urls: list[str], lastmod: str) -> str:
+def sitemap_xml(urls: list[str]) -> str:
     root = Element("urlset", {"xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9"})
     for url in urls:
         node = SubElement(root, "url")
         SubElement(node, "loc").text = url
-        SubElement(node, "lastmod").text = lastmod
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + tostring(root, encoding="unicode") + "\n"
 
 
@@ -378,10 +377,9 @@ def render(events_path: Path, public_root: Path, base_url: str = BASE_URL) -> di
             render_event_page(event, base_url), encoding="utf-8"
         )
 
-    lastmod = generated_at.isoformat().replace("+00:00", "Z")
     urls = [base_url + "/"] + [f"{base_url}/events/{event_id}/" for event_id in ids]
     (public_root / "sitemap.xml").write_text(
-        sitemap_xml(urls, lastmod), encoding="utf-8"
+        sitemap_xml(urls), encoding="utf-8"
     )
     write_analytics(public_root)
     patch_root(public_root, selected)

--- a/tests/test_search_pages.py
+++ b/tests/test_search_pages.py
@@ -70,6 +70,7 @@ def test_render_search_pages_is_truthful_bounded_and_idempotent(tmp_path: Path) 
     assert "https://example.test/project/" in sitemap
     assert "https://example.test/project/events/future-1/" in sitemap
     assert "past-1" not in sitemap
+    assert "<lastmod>" not in sitemap
 
     index = (root / "index.html").read_text(encoding="utf-8")
     assert index.count("searchable-events:start") == 1


### PR DESCRIPTION
Fixes the remaining truthfulness gap in #65.

Current `public/sitemap.xml` assigns `events.json.generated_at` to `<lastmod>` for every URL, even when a page's content did not change. Google Search Central says `<lastmod>` should reflect the last significant page update and is only useful when consistently accurate; it may be omitted when the modification time is not known reliably.

This change:
- deletes the generated-at -> page-lastmod mapping;
- emits only canonical `<loc>` entries until a page-specific significant-modification authority exists;
- adds a regression assertion that generated sitemaps contain no invented `<lastmod>` values.

No new schema, dependency, collector, or SEO framework. Canonical URL selection and indexability rules remain unchanged.

Primary source: https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap