### PR TITLE
feat: guarantee zero-orphan crawl graph for search pages

### DIFF
--- a/.github/workflows/render-search-pages.yml
+++ b/.github/workflows/render-search-pages.yml
@@ -8,9 +8,12 @@ on:
       - scripts/render_search_pages.py
       - scripts/render_category_pages.py
       - scripts/render_series_pages.py
+      - scripts/render_internal_links.py
+      - scripts/verify_crawl_graph.py
       - tests/test_search_pages.py
       - tests/test_category_pages.py
       - tests/test_series_pages.py
+      - tests/test_crawl_graph.py
       - public/category-ontology.json
       - .github/workflows/render-search-pages.yml
   pull_request:
@@ -18,9 +21,12 @@ on:
       - scripts/render_search_pages.py
       - scripts/render_category_pages.py
       - scripts/render_series_pages.py
+      - scripts/render_internal_links.py
+      - scripts/verify_crawl_graph.py
       - tests/test_search_pages.py
       - tests/test_category_pages.py
       - tests/test_series_pages.py
+      - tests/test_crawl_graph.py
       - public/category-ontology.json
       - .github/workflows/render-search-pages.yml
   workflow_run:
@@ -47,10 +53,12 @@ jobs:
           python-version: '3.12'
           cache: pip
       - run: pip install -e '.[dev]'
-      - run: pytest tests/test_search_pages.py tests/test_category_pages.py tests/test_series_pages.py -q
+      - run: pytest tests/test_search_pages.py tests/test_category_pages.py tests/test_series_pages.py tests/test_crawl_graph.py -q
       - run: python scripts/render_search_pages.py
       - run: python scripts/render_category_pages.py
       - run: python scripts/render_series_pages.py
+      - run: python scripts/render_internal_links.py
+      - run: python scripts/verify_crawl_graph.py
 
   publish:
     if: github.event_name != 'pull_request' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
@@ -74,6 +82,10 @@ jobs:
         run: python scripts/render_category_pages.py
       - name: Render canonical series landing pages
         run: python scripts/render_series_pages.py
+      - name: Connect canonical search pages
+        run: python scripts/render_internal_links.py
+      - name: Verify crawl graph
+        run: python scripts/verify_crawl_graph.py
       - name: Verify real public snapshot
         run: |
           python - <<'PY'
@@ -89,23 +101,14 @@ jobs:
           ns = {'s': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
           urls = [node.text for node in sitemap.findall('s:url/s:loc', ns)]
           assert events['count'] == len(events['events'])
-          assert event_pages
-          assert category_pages
-          assert series_pages
+          assert event_pages and category_pages and series_pages
           assert len(urls) == len(event_pages) + len(category_pages) + len(series_pages) + 1
           assert len(urls) == len(set(urls))
           assert urls[0] == 'https://kafka2306.github.io/vrc_cast_event_calender/'
           assert all('application/ld+json' not in page.read_text(encoding='utf-8') for page in event_pages)
-          for page in category_pages:
-              text = page.read_text(encoding='utf-8')
-              assert 'rel="canonical"' in text
-              assert '../../events/' in text
-          for page in series_pages:
-              text = page.read_text(encoding='utf-8')
-              assert 'rel="canonical"' in text
-              assert '<h2>公式情報</h2>' in text
           index = Path('public/index.html').read_text(encoding='utf-8')
           assert 'searchable-events:start' in index
+          assert 'crawl-hubs:start' in index
           assert 'analytics.js' in index
           print(json.dumps({
               'event_pages': len(event_pages),

--- a/.github/workflows/render-search-pages.yml
+++ b/.github/workflows/render-search-pages.yml
@@ -34,7 +34,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: cast-event-calendar-production
+  group: ${{ github.event_name == 'pull_request' && format('search-pr-{0}', github.event.pull_request.number) || 'cast-event-calendar-production' }}
   cancel-in-progress: false
 
 permissions:

--- a/scripts/render_internal_links.py
+++ b/scripts/render_internal_links.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    from scripts.render_search_pages import parse_time
+except ModuleNotFoundError:
+    from render_search_pages import parse_time
+
+ROOT_HUB_START = "<!-- crawl-hubs:start -->"
+ROOT_HUB_END = "<!-- crawl-hubs:end -->"
+ROOT_EVENTS_START = "<!-- crawl-all-events:start -->"
+ROOT_EVENTS_END = "<!-- crawl-all-events:end -->"
+EVENT_LINKS_START = "<!-- event-crawl-links:start -->"
+EVENT_LINKS_END = "<!-- event-crawl-links:end -->"
+CATEGORY_LINK_START = "<!-- category-related:start -->"
+CATEGORY_LINK_END = "<!-- category-related:end -->"
+
+
+def esc(value: object) -> str:
+    return html.escape(str(value or ""), quote=True)
+
+
+def replace_block(text: str, start: str, end: str, block: str, marker: str) -> str:
+    text = re.sub(re.escape(start) + r".*?" + re.escape(end), "", text, flags=re.S)
+    if marker not in text:
+        raise ValueError(f"HTML marker missing: {marker}")
+    return text.replace(marker, f"{start}{block}{end}{marker}", 1)
+
+
+def page_label(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"<h1>(.*?)</h1>", text, flags=re.S)
+    if not match:
+        return path.parent.name
+    return html.unescape(re.sub(r"<[^>]+>", "", match.group(1))).strip() or path.parent.name
+
+
+def render(public_root: Path) -> dict[str, int]:
+    payload = json.loads((public_root / "events.json").read_text(encoding="utf-8"))
+    rows = payload.get("events")
+    if not isinstance(rows, list):
+        raise ValueError("events.json events must be a list")
+    by_id = {str(row.get("id")): row for row in rows if isinstance(row, dict) and row.get("id")}
+
+    event_paths = sorted((public_root / "events").glob("*/index.html"))
+    event_ids = {path.parent.name for path in event_paths}
+    category_paths = sorted((public_root / "categories").glob("*/index.html"))
+    series_paths = sorted((public_root / "series").glob("*/index.html"))
+    category_labels = {path.parent.name: page_label(path) for path in category_paths}
+    series_labels = {path.parent.name: page_label(path) for path in series_paths}
+
+    ordered_event_ids = sorted(
+        event_ids,
+        key=lambda event_id: (
+            parse_time(by_id.get(event_id, {}).get("starts_at")) is None,
+            parse_time(by_id.get(event_id, {}).get("starts_at")) or parse_time("9999-12-31T00:00:00Z"),
+            event_id,
+        ),
+    )
+
+    root_path = public_root / "index.html"
+    root = root_path.read_text(encoding="utf-8")
+    category_items = "".join(
+        f'<li><a href="categories/{esc(category_id)}/">{esc(label)}</a></li>'
+        for category_id, label in sorted(category_labels.items())
+    )
+    series_items = "".join(
+        f'<li><a href="series/{esc(series_id)}/">{esc(label)}</a></li>'
+        for series_id, label in sorted(series_labels.items(), key=lambda item: item[1])
+    )
+    hubs = (
+        '<section class="search-entry" aria-labelledby="crawl-hubs-title">'
+        '<div class="eyebrow">DISCOVER BY TOPIC</div>'
+        '<h2 id="crawl-hubs-title">カテゴリ・定期イベントから探す</h2>'
+        f'<h3>カテゴリ</h3><ul>{category_items}</ul>'
+        f'<h3>定期イベント</h3><ul>{series_items}</ul>'
+        '</section>'
+    )
+    root = replace_block(root, ROOT_HUB_START, ROOT_HUB_END, hubs, "<footer>")
+
+    existing_root_ids = set(re.findall(r'href="events/([^/]+)/"', root))
+    remaining = [event_id for event_id in ordered_event_ids if event_id not in existing_root_ids]
+    remaining_items = "".join(
+        '<li><a href="events/{id}/" data-track="event_detail_open" data-event-id="{id}" '
+        'data-category="{category}">{title}</a></li>'.format(
+            id=esc(event_id),
+            category=esc(by_id.get(event_id, {}).get("category")),
+            title=esc(by_id.get(event_id, {}).get("canonical_name") or by_id.get(event_id, {}).get("title") or event_id),
+        )
+        for event_id in remaining
+    )
+    all_events = (
+        '<details class="search-entry"><summary>すべてのイベント詳細を開く'
+        f'（残り{len(remaining)}件）</summary><ul>{remaining_items}</ul></details>'
+    )
+    root = replace_block(root, ROOT_EVENTS_START, ROOT_EVENTS_END, all_events, "<footer>")
+    root_path.write_text(root, encoding="utf-8")
+
+    category_ids = sorted(category_labels)
+    category_related_links = 0
+    for index, category_id in enumerate(category_ids):
+        path = public_root / "categories" / category_id / "index.html"
+        text = path.read_text(encoding="utf-8")
+        related = ""
+        if len(category_ids) > 1:
+            related_id = category_ids[(index + 1) % len(category_ids)]
+            related = f'<a href="../{esc(related_id)}/">関連カテゴリ: {esc(category_labels[related_id])}</a>'
+            category_related_links += 1
+        text = replace_block(text, CATEGORY_LINK_START, CATEGORY_LINK_END, related, "</nav>")
+        path.write_text(text, encoding="utf-8")
+
+    events_by_category: dict[str, list[str]] = defaultdict(list)
+    for event_id in ordered_event_ids:
+        category = str(by_id.get(event_id, {}).get("category") or "")
+        events_by_category[category].append(event_id)
+
+    event_category_links = 0
+    event_related_links = 0
+    for event_id in ordered_event_ids:
+        path = public_root / "events" / event_id / "index.html"
+        text = path.read_text(encoding="utf-8")
+        event = by_id.get(event_id, {})
+        category = str(event.get("category") or "")
+        links: list[str] = []
+        if category in category_labels:
+            links.append(f'<a href="../../categories/{esc(category)}/">カテゴリを見る</a>')
+            event_category_links += 1
+        peers = events_by_category.get(category, [])
+        if len(peers) > 1:
+            position = peers.index(event_id)
+            related_id = peers[(position + 1) % len(peers)]
+            links.append(f'<a href="../{esc(related_id)}/">関連イベントを見る</a>')
+            event_related_links += 1
+        text = replace_block(text, EVENT_LINKS_START, EVENT_LINKS_END, "".join(links), "</nav>")
+        path.write_text(text, encoding="utf-8")
+
+    return {
+        "root_event_links": len(ordered_event_ids),
+        "root_category_links": len(category_ids),
+        "root_series_links": len(series_labels),
+        "event_category_links": event_category_links,
+        "event_related_links": event_related_links,
+        "category_related_links": category_related_links,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--public-root", type=Path, default=Path("public"))
+    args = parser.parse_args()
+    print(json.dumps(render(args.public_root), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_crawl_graph.py
+++ b/scripts/verify_crawl_graph.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, deque
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urljoin, urlparse, urlunparse
+from xml.etree import ElementTree as ET
+
+try:
+    from scripts.render_search_pages import BASE_URL
+except ModuleNotFoundError:
+    from render_search_pages import BASE_URL
+
+SEARCH_PREFIXES = ("events/", "categories/", "series/")
+
+
+class AnchorParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "a":
+            return
+        for name, value in attrs:
+            if name == "href" and value:
+                self.hrefs.append(value)
+
+
+def canonicalize(url: str) -> str:
+    parsed = urlparse(url)
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+
+
+def url_to_file(public_root: Path, url: str, base_url: str) -> Path:
+    if url == base_url:
+        return public_root / "index.html"
+    parsed = urlparse(url)
+    base = urlparse(base_url)
+    prefix = base.path.rstrip("/") + "/"
+    if parsed.scheme != base.scheme or parsed.netloc != base.netloc or not parsed.path.startswith(prefix):
+        raise ValueError(f"URL outside canonical host/path: {url}")
+    relative = parsed.path[len(prefix):].rstrip("/")
+    return public_root / relative / "index.html"
+
+
+def sitemap_urls(public_root: Path) -> list[str]:
+    sitemap = ET.parse(public_root / "sitemap.xml").getroot()
+    ns = {"s": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    urls = [node.text for node in sitemap.findall("s:url/s:loc", ns)]
+    if any(not isinstance(url, str) for url in urls):
+        raise ValueError("sitemap contains an empty URL")
+    return [canonicalize(str(url)) for url in urls]
+
+
+def verify(public_root: Path, base_url: str = BASE_URL) -> dict[str, object]:
+    base_url = base_url.rstrip("/") + "/"
+    urls = sitemap_urls(public_root)
+    if not urls or urls[0] != base_url:
+        raise ValueError("sitemap must start with canonical homepage")
+    if len(urls) != len(set(urls)):
+        raise ValueError("sitemap contains duplicate URLs")
+
+    canonical = set(urls)
+    graph: dict[str, set[str]] = {url: set() for url in urls}
+    broken_search_links: list[str] = []
+    base = urlparse(base_url)
+    search_root = base.path.rstrip("/") + "/"
+
+    for page_url in urls:
+        path = url_to_file(public_root, page_url, base_url)
+        if not path.is_file():
+            raise ValueError(f"sitemap HTML missing: {page_url}")
+        parser = AnchorParser()
+        parser.feed(path.read_text(encoding="utf-8"))
+        for href in parser.hrefs:
+            target = canonicalize(urljoin(page_url, href))
+            if target in canonical:
+                graph[page_url].add(target)
+                continue
+            parsed = urlparse(target)
+            if parsed.scheme == base.scheme and parsed.netloc == base.netloc and parsed.path.startswith(search_root):
+                relative = parsed.path[len(search_root):]
+                if relative.startswith(SEARCH_PREFIXES):
+                    broken_search_links.append(f"{page_url} -> {target}")
+
+    if broken_search_links:
+        preview = "; ".join(sorted(set(broken_search_links))[:10])
+        raise ValueError(f"broken/non-canonical search links: {preview}")
+
+    indegree: Counter[str] = Counter()
+    for targets in graph.values():
+        for target in targets:
+            if target != base_url:
+                indegree[target] += 1
+    orphans = sorted(url for url in urls if url != base_url and indegree[url] == 0)
+    if orphans:
+        raise ValueError("orphan indexable pages: " + ", ".join(orphans[:10]))
+
+    depth = {base_url: 0}
+    queue: deque[str] = deque([base_url])
+    while queue:
+        source = queue.popleft()
+        for target in sorted(graph[source]):
+            if target not in depth:
+                depth[target] = depth[source] + 1
+                queue.append(target)
+    unreachable = sorted(canonical - set(depth))
+    if unreachable:
+        raise ValueError("indexable pages unreachable from homepage: " + ", ".join(unreachable[:10]))
+
+    event_urls = sorted(url for url in urls if "/events/" in url)
+    event_without_inbound = [url for url in event_urls if indegree[url] == 0]
+    if event_without_inbound:
+        raise ValueError("event pages without inbound links: " + ", ".join(event_without_inbound[:10]))
+
+    depth_histogram = Counter(depth.values())
+    return {
+        "page_count": len(urls),
+        "event_page_count": len(event_urls),
+        "edge_count": sum(len(targets) for targets in graph.values()),
+        "orphan_count": 0,
+        "broken_search_link_count": 0,
+        "unreachable_count": 0,
+        "event_pages_without_inbound": 0,
+        "max_depth": max(depth.values(), default=0),
+        "depth_histogram": {str(level): count for level, count in sorted(depth_histogram.items())},
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--public-root", type=Path, default=Path("public"))
+    parser.add_argument("--base-url", default=BASE_URL)
+    args = parser.parse_args()
+    print(json.dumps(verify(args.public_root, args.base_url), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_crawl_graph.py
+++ b/tests/test_crawl_graph.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.render_category_pages import render as render_categories
+from scripts.render_internal_links import render as render_links
+from scripts.render_search_pages import render as render_events
+from scripts.render_series_pages import render as render_series
+from scripts.verify_crawl_graph import verify
+
+
+def _root(tmp_path: Path) -> Path:
+    (tmp_path / "index.html").write_text(
+        '<!doctype html><html><head><style>:root{--line:#ddd;--radius:20px;--muted:#666}.eyebrow{}</style></head>'
+        '<body><a class="button" href="calendar.ics">カレンダーを購読</a><footer>footer</footer></body></html>',
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _build_surface(tmp_path: Path) -> Path:
+    root = _root(tmp_path)
+    payload = {
+        "generated_at": "2026-08-16T00:00:00Z",
+        "events": [
+            {
+                "id": "social-1",
+                "title": "交流会 1",
+                "canonical_name": "毎週交流会",
+                "starts_at": "2026-08-17T12:00:00Z",
+                "category": "community",
+                "category_label": "交流・カフェ",
+                "ontology_id": "weekly-social",
+                "primary_action_url": "https://example.com/social-1",
+            },
+            {
+                "id": "social-2",
+                "title": "交流会 2",
+                "canonical_name": "毎週交流会",
+                "starts_at": "2026-08-24T12:00:00Z",
+                "category": "community",
+                "category_label": "交流・カフェ",
+                "ontology_id": "weekly-social",
+                "primary_action_url": "https://example.com/social-2",
+            },
+            {
+                "id": "music-1",
+                "title": "音楽イベント",
+                "starts_at": "2026-08-18T12:00:00Z",
+                "category": "music",
+                "category_label": "音楽・ダンス",
+                "primary_action_url": "https://example.com/music-1",
+            },
+        ],
+    }
+    category_ontology = {
+        "categories": [
+            {"id": "community", "label": "交流・カフェ", "priority": 60},
+            {"id": "music", "label": "音楽・ダンス", "priority": 90},
+            {"id": "other", "label": "その他", "priority": 0},
+        ]
+    }
+    event_ontology = {
+        "entries": [
+            {
+                "canonical_id": "weekly-social",
+                "canonical_name": "毎週交流会",
+                "organizers": ["交流会公式"],
+                "category": "community",
+                "schedule": {"type": "recurring", "cadence": "毎週開催"},
+                "introduction": "毎週の交流イベントです。",
+                "participation_method": "公式Groupから参加。",
+                "first_time_guide": "公式案内を確認してください。",
+                "highlights": ["定期開催"],
+                "official_links": [
+                    {"label": "VRChat Group", "url": "https://example.com/group", "kind": "vrchat_group"}
+                ],
+                "curation": {"status": "human_curated"},
+            }
+        ],
+        "observed_entities": [
+            {
+                "entity_id": "weekly-social-official",
+                "latest_observed_start": "2026-08-24T12:00:00Z",
+                "matched_ontology_ids": {"weekly-social": 2},
+            }
+        ],
+    }
+    events_path = root / "events.json"
+    category_path = root / "category-ontology.json"
+    ontology_path = root / "event-ontology.json"
+    events_path.write_text(json.dumps(payload), encoding="utf-8")
+    category_path.write_text(json.dumps(category_ontology), encoding="utf-8")
+    ontology_path.write_text(json.dumps(event_ontology), encoding="utf-8")
+
+    base = "https://example.test/project"
+    render_events(events_path, root, base)
+    render_categories(events_path, category_path, root, base)
+    render_series(events_path, ontology_path, root, base)
+    render_links(root)
+    return root
+
+
+def test_crawl_graph_has_zero_orphans_and_static_hub_links(tmp_path: Path) -> None:
+    root = _build_surface(tmp_path)
+    result = verify(root, "https://example.test/project")
+
+    assert result["page_count"] == 7
+    assert result["event_page_count"] == 3
+    assert result["orphan_count"] == 0
+    assert result["broken_search_link_count"] == 0
+    assert result["unreachable_count"] == 0
+    assert result["event_pages_without_inbound"] == 0
+    assert result["max_depth"] == 1
+
+    index = (root / "index.html").read_text(encoding="utf-8")
+    assert 'href="categories/community/"' in index
+    assert 'href="series/weekly-social/"' in index
+    detail = (root / "events/social-1/index.html").read_text(encoding="utf-8")
+    assert 'href="../../categories/community/"' in detail
+    assert 'href="../social-2/"' in detail
+    assert 'href="../../series/weekly-social/"' in detail
+
+
+def test_crawl_graph_rejects_broken_search_link(tmp_path: Path) -> None:
+    root = _build_surface(tmp_path)
+    index = root / "index.html"
+    text = index.read_text(encoding="utf-8")
+    index.write_text(text.replace("<footer>", '<a href="events/missing/">broken</a><footer>', 1), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="broken/non-canonical search links"):
+        verify(root, "https://example.test/project")
+
+
+def test_crawl_graph_rejects_orphan_page(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    (root / "events/orphan").mkdir(parents=True)
+    (root / "events/orphan/index.html").write_text("<!doctype html><p>orphan</p>", encoding="utf-8")
+    (root / "sitemap.xml").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        '<url><loc>https://example.test/project/</loc></url>'
+        '<url><loc>https://example.test/project/events/orphan/</loc></url>'
+        '</urlset>',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="orphan indexable pages"):
+        verify(root, "https://example.test/project")


### PR DESCRIPTION
## Goal

Implement the canonical portion of #94: every indexable event/category/series page must be reachable through crawlable HTML links, not sitemap-only discovery.

## Change

- add one final `render_internal_links.py` pass after event/category/series generation
- homepage links all generated categories and recurring series
- homepage preserves the 24-event preview and adds crawlable links for every remaining event detail inside native `<details>`
- event detail links to its category and a deterministic next event in the same category
- category pages link to a deterministic related category
- existing event↔series and series→category/event links remain intact
- add `verify_crawl_graph.py` using only stdlib HTML parsing + BFS

## Fail-closed checks

- orphan indexable pages = 0
- all sitemap HTML reachable from homepage
- every event detail has inbound HTML link
- broken/non-canonical event/category/series internal links = 0
- report max homepage link depth and edge count

## Scope boundary

The delivery-owned `/tonight/` → stable event detail link remains a separate patch in `KAFKA2306/vrc_cast_event_calender`; #94 should remain open until that is live.

Related: #94