### PR TITLE
fix: keep homepage crawl links idempotent across rerenders

### DIFF
--- a/scripts/render_internal_links.py
+++ b/scripts/render_internal_links.py
@@ -26,8 +26,12 @@ def esc(value: object) -> str:
     return html.escape(str(value or ""), quote=True)
 
 
+def strip_block(text: str, start: str, end: str) -> str:
+    return re.sub(re.escape(start) + r".*?" + re.escape(end), "", text, flags=re.S)
+
+
 def replace_block(text: str, start: str, end: str, block: str, marker: str) -> str:
-    text = re.sub(re.escape(start) + r".*?" + re.escape(end), "", text, flags=re.S)
+    text = strip_block(text, start, end)
     if marker not in text:
         raise ValueError(f"HTML marker missing: {marker}")
     return text.replace(marker, f"{start}{block}{end}{marker}", 1)
@@ -84,6 +88,7 @@ def render(public_root: Path) -> dict[str, int]:
     )
     root = replace_block(root, ROOT_HUB_START, ROOT_HUB_END, hubs, "<footer>")
 
+    root = strip_block(root, ROOT_EVENTS_START, ROOT_EVENTS_END)
     existing_root_ids = set(re.findall(r'href="events/([^/]+)/"', root))
     remaining = [event_id for event_id in ordered_event_ids if event_id not in existing_root_ids]
     remaining_items = "".join(

--- a/tests/test_crawl_graph.py
+++ b/tests/test_crawl_graph.py
@@ -125,6 +125,19 @@ def test_crawl_graph_has_zero_orphans_and_static_hub_links(tmp_path: Path) -> No
     assert 'href="../../series/weekly-social/"' in detail
 
 
+def test_crawl_link_render_is_idempotent(tmp_path: Path) -> None:
+    root = _build_surface(tmp_path)
+    first = (root / "index.html").read_text(encoding="utf-8")
+
+    render_links(root)
+
+    second = (root / "index.html").read_text(encoding="utf-8")
+    assert second == first
+    result = verify(root, "https://example.test/project")
+    assert result["max_depth"] == 1
+    assert result["orphan_count"] == 0
+
+
 def test_crawl_graph_rejects_broken_search_link(tmp_path: Path) -> None:
     root = _build_surface(tmp_path)
     index = root / "index.html"


### PR DESCRIPTION
## Goal

Repair the #94 production regression where a second search render removed most homepage event links.

## Root cause

`render_internal_links.py` counted event links from the previous `crawl-all-events` block as if they were the 24 normal preview links, then removed that old block. On the second render, the replacement block was therefore empty. The graph remained connected through related-event chains, but homepage max depth regressed from 1 to 11.

## Change

- strip the previous `crawl-all-events` block before calculating which event links are already present in the normal homepage preview
- retain the existing deterministic replacement after that calculation
- add a regression test that runs the internal-link renderer twice and requires byte-identical homepage output plus `max_depth == 1`

## Production evidence that caught it

Delivery run `31941455833` failed closed with missing homepage event links while validating canonical main `31e35b0140df7971e818ee73abd8c8cd60597d00`.

Related: #94