### PR TITLE
feat: publish deterministic event social cards and share controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,15 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install -e '.[dev]'
       - run: ruff check cast_event_cal scripts tests
-      - run: pytest
+      - name: Run pytest
+        run: |
+          set +e
+          pytest -x -vv 2>&1 | tee /tmp/pytest.log
+          status=${PIPESTATUS[0]}
+          if [ "$status" -ne 0 ]; then
+            tail -40 /tmp/pytest.log | tr '\n' '|' | sed 's/%/%25/g; s/\r/%0D/g; s/\n/%0A/g' | while IFS= read -r line; do echo "::error title=pytest failure::$line"; done
+          fi
+          exit "$status"
       - run: cast-event-cal validate
       - run: python scripts/materialize_events.py
       - name: Exercise credential-free discovery fallback

--- a/.github/workflows/render-search-pages.yml
+++ b/.github/workflows/render-search-pages.yml
@@ -8,26 +8,32 @@ on:
       - scripts/render_search_pages.py
       - scripts/render_category_pages.py
       - scripts/render_series_pages.py
+      - scripts/render_social_assets.py
       - scripts/render_internal_links.py
       - scripts/verify_crawl_graph.py
       - tests/test_search_pages.py
       - tests/test_category_pages.py
       - tests/test_series_pages.py
+      - tests/test_social_assets.py
       - tests/test_crawl_graph.py
       - public/category-ontology.json
+      - pyproject.toml
       - .github/workflows/render-search-pages.yml
   pull_request:
     paths:
       - scripts/render_search_pages.py
       - scripts/render_category_pages.py
       - scripts/render_series_pages.py
+      - scripts/render_social_assets.py
       - scripts/render_internal_links.py
       - scripts/verify_crawl_graph.py
       - tests/test_search_pages.py
       - tests/test_category_pages.py
       - tests/test_series_pages.py
+      - tests/test_social_assets.py
       - tests/test_crawl_graph.py
       - public/category-ontology.json
+      - pyproject.toml
       - .github/workflows/render-search-pages.yml
   workflow_run:
     workflows: ["Update calendar data"]
@@ -53,10 +59,16 @@ jobs:
           python-version: '3.12'
           cache: pip
       - run: pip install -e '.[dev]'
-      - run: pytest tests/test_search_pages.py tests/test_category_pages.py tests/test_series_pages.py tests/test_crawl_graph.py -q
+      - name: Install Japanese font for deterministic OG rendering
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fonts-noto-cjk
+          test -f /usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc
+      - run: pytest tests/test_search_pages.py tests/test_category_pages.py tests/test_series_pages.py tests/test_social_assets.py tests/test_crawl_graph.py -q
       - run: python scripts/render_search_pages.py
       - run: python scripts/render_category_pages.py
       - run: python scripts/render_series_pages.py
+      - run: python scripts/render_social_assets.py
       - run: python scripts/render_internal_links.py
       - run: python scripts/verify_crawl_graph.py
 
@@ -76,12 +88,21 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: pip
+      - run: pip install -e .
+      - name: Install Japanese font for deterministic OG rendering
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fonts-noto-cjk
+          test -f /usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc
       - name: Render current/future crawlable event pages
         run: python scripts/render_search_pages.py
       - name: Render category landing pages
         run: python scripts/render_category_pages.py
       - name: Render canonical series landing pages
         run: python scripts/render_series_pages.py
+      - name: Render event OG images and share controls
+        run: python scripts/render_social_assets.py
       - name: Connect canonical search pages
         run: python scripts/render_internal_links.py
       - name: Verify crawl graph
@@ -92,28 +113,43 @@ jobs:
           import json
           import xml.etree.ElementTree as ET
           from pathlib import Path
+          from PIL import Image
 
           events = json.loads(Path('public/events.json').read_text(encoding='utf-8'))
           event_pages = sorted(Path('public/events').glob('*/index.html'))
           category_pages = sorted(Path('public/categories').glob('*/index.html'))
           series_pages = sorted(Path('public/series').glob('*/index.html'))
+          og_images = sorted(Path('public/og/events').glob('*.png'))
           sitemap = ET.parse('public/sitemap.xml').getroot()
           ns = {'s': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
           urls = [node.text for node in sitemap.findall('s:url/s:loc', ns)]
           assert events['count'] == len(events['events'])
           assert event_pages and category_pages and series_pages
+          assert len(og_images) == len(event_pages)
           assert len(urls) == len(event_pages) + len(category_pages) + len(series_pages) + 1
           assert len(urls) == len(set(urls))
           assert urls[0] == 'https://kafka2306.github.io/vrc_cast_event_calender/'
           assert all('application/ld+json' not in page.read_text(encoding='utf-8') for page in event_pages)
+          for page in event_pages:
+              text = page.read_text(encoding='utf-8')
+              assert 'social-meta:start' in text
+              assert 'share-controls:start' in text
+              assert 'twitter:card" content="summary_large_image' in text
+              assert '../../share.js' in text
+          for path in og_images[:3]:
+              with Image.open(path) as image:
+                  assert image.format == 'PNG'
+                  assert image.size == (1200, 630)
           index = Path('public/index.html').read_text(encoding='utf-8')
           assert 'searchable-events:start' in index
           assert 'crawl-hubs:start' in index
           assert 'analytics.js' in index
+          assert Path('public/share.js').is_file()
           print(json.dumps({
               'event_pages': len(event_pages),
               'category_pages': len(category_pages),
               'series_pages': len(series_pages),
+              'og_images': len(og_images),
               'sitemap_urls': len(urls),
           }, sort_keys=True))
           PY
@@ -122,7 +158,7 @@ jobs:
           set -euo pipefail
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add public/index.html public/events public/categories public/series public/sitemap.xml public/analytics.js public/analytics-config.json
+          git add public/index.html public/events public/categories public/series public/og public/sitemap.xml public/analytics.js public/analytics-config.json public/share.js
           if git diff --cached --quiet; then
             echo 'Search surface is already current'
           else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = { text = "MIT" }
 authors = [{ name = "KAFKA2306" }]
 dependencies = [
   "httpx>=0.28,<1",
+  "Pillow>=11,<13",
   "PyYAML>=6.0.2,<7",
   "python-dateutil>=2.9,<3",
 ]

--- a/scripts/render_social_assets.py
+++ b/scripts/render_social_assets.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import os
+import re
+import shutil
+import textwrap
+from pathlib import Path
+from urllib.parse import urlencode
+
+from PIL import Image, ImageDraw, ImageFont
+
+try:
+    from scripts.render_search_pages import BASE_URL, event_title, format_jst, indexable, parse_time
+except ModuleNotFoundError:
+    from render_search_pages import BASE_URL, event_title, format_jst, indexable, parse_time
+
+WIDTH = 1200
+HEIGHT = 630
+SOCIAL_META_START = "<!-- social-meta:start -->"
+SOCIAL_META_END = "<!-- social-meta:end -->"
+SHARE_START = "<!-- share-controls:start -->"
+SHARE_END = "<!-- share-controls:end -->"
+FONT_CANDIDATES = (
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/opentype/noto/NotoSansCJKjp-Regular.otf",
+    "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+)
+
+
+def esc(value: object) -> str:
+    return html.escape(str(value or ""), quote=True)
+
+
+def strip_block(text: str, start: str, end: str) -> str:
+    return re.sub(re.escape(start) + r".*?" + re.escape(end), "", text, flags=re.S)
+
+
+def resolve_font(explicit: Path | None = None) -> Path | None:
+    candidates = [explicit, Path(os.environ["OG_FONT_PATH"]) if os.environ.get("OG_FONT_PATH") else None]
+    candidates.extend(Path(value) for value in FONT_CANDIDATES)
+    return next((path for path in candidates if path and path.is_file()), None)
+
+
+def load_font(path: Path | None, size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    return ImageFont.truetype(str(path), size=size) if path else ImageFont.load_default(size=size)
+
+
+def fit_lines(draw: ImageDraw.ImageDraw, value: str, font: ImageFont.ImageFont, max_width: int, max_lines: int) -> list[str]:
+    value = " ".join(value.split())
+    if not value:
+        return [""]
+    lines: list[str] = []
+    current = ""
+    for char in value:
+        candidate = current + char
+        if current and draw.textlength(candidate, font=font) > max_width:
+            lines.append(current)
+            current = char
+            if len(lines) == max_lines:
+                break
+        else:
+            current = candidate
+    if len(lines) < max_lines and current:
+        lines.append(current)
+    consumed = "".join(lines)
+    if len(consumed) < len(value) and lines:
+        last = lines[-1]
+        while last and draw.textlength(last + "…", font=font) > max_width:
+            last = last[:-1]
+        lines[-1] = last.rstrip() + "…"
+    return lines[:max_lines]
+
+
+def accent_for(category: str) -> tuple[int, int, int]:
+    palette = (
+        (203, 224, 255),
+        (220, 236, 211),
+        (250, 220, 222),
+        (244, 226, 194),
+        (224, 218, 244),
+        (208, 235, 232),
+    )
+    digest = hashlib.sha256(category.encode("utf-8")).digest()[0]
+    return palette[digest % len(palette)]
+
+
+def draw_card(event: dict[str, object], target: Path, font_path: Path | None) -> None:
+    image = Image.new("RGB", (WIDTH, HEIGHT), (251, 250, 247))
+    draw = ImageDraw.Draw(image)
+    ink = (36, 54, 83)
+    muted = (95, 110, 132)
+    category = str(event.get("category_label") or event.get("category") or "VRChat EVENT")
+    accent = accent_for(str(event.get("category") or category))
+    title = event_title(event)
+    start = format_jst(event.get("starts_at"))
+
+    brand_font = load_font(font_path, 28)
+    pill_font = load_font(font_path, 27)
+    title_font = load_font(font_path, 62)
+    date_font = load_font(font_path, 34)
+    foot_font = load_font(font_path, 24)
+
+    draw.rounded_rectangle((48, 44, WIDTH - 48, HEIGHT - 44), radius=34, fill=(255, 255, 255), outline=(223, 230, 239), width=2)
+    draw.rounded_rectangle((48, 44, WIDTH - 48, 70), radius=13, fill=accent)
+    draw.text((84, 94), "VRCHAT EVENT CALENDAR", font=brand_font, fill=muted)
+
+    pill_box = draw.textbbox((0, 0), category, font=pill_font)
+    pill_width = min(WIDTH - 168, pill_box[2] - pill_box[0] + 44)
+    draw.rounded_rectangle((84, 150, 84 + pill_width, 198), radius=24, fill=accent)
+    draw.text((106, 157), category, font=pill_font, fill=ink)
+
+    y = 236
+    for line in fit_lines(draw, title, title_font, WIDTH - 168, 3):
+        draw.text((84, y), line, font=title_font, fill=ink)
+        y += 78
+
+    draw.text((84, 490), start, font=date_font, fill=ink)
+    draw.line((84, 548, WIDTH - 84, 548), fill=(223, 230, 239), width=2)
+    draw.text((84, 566), "詳細URLを共有して、参加前に最新の公式情報を確認", font=foot_font, fill=muted)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    image.save(target, format="PNG", optimize=True, compress_level=9)
+
+
+def social_meta(event: dict[str, object], base_url: str) -> str:
+    event_id = str(event["id"])
+    title = event_title(event)
+    image = f"{base_url}/og/events/{event_id}.png"
+    return (
+        f'{SOCIAL_META_START}\n'
+        f'<meta property="og:image" content="{esc(image)}">\n'
+        '<meta property="og:image:type" content="image/png">\n'
+        f'<meta property="og:image:alt" content="{esc(title)}">\n'
+        f'<meta property="og:image:width" content="{WIDTH}">\n'
+        f'<meta property="og:image:height" content="{HEIGHT}">\n'
+        '<meta name="twitter:card" content="summary_large_image">\n'
+        f'<meta name="twitter:image" content="{esc(image)}">\n'
+        f'<meta name="twitter:image:alt" content="{esc(title)}">\n'
+        f'{SOCIAL_META_END}'
+    )
+
+
+def share_controls(event: dict[str, object], base_url: str) -> str:
+    event_id = str(event["id"])
+    category = str(event.get("category") or "")
+    title = event_title(event)
+    canonical = f"{base_url}/events/{event_id}/"
+    native_url = canonical + "?" + urlencode({"utm_source": "share", "utm_medium": "social", "utm_campaign": "event_share"})
+    x_url = canonical + "?" + urlencode({"utm_source": "x", "utm_medium": "social", "utm_campaign": "event_share"})
+    intent = "https://x.com/intent/tweet?" + urlencode({"text": title, "url": x_url})
+    return (
+        f'{SHARE_START}<div class="actions share-actions">'
+        f'<button class="action" type="button" data-share-native data-share-url="{esc(native_url)}" '
+        f'data-share-title="{esc(title)}" data-track="share_click" data-event-id="{esc(event_id)}" '
+        f'data-category="{esc(category)}" data-destination-type="native">共有 / URLコピー</button>'
+        f'<a class="action" href="{esc(intent)}" target="_blank" rel="noopener noreferrer" '
+        f'data-track="share_click" data-event-id="{esc(event_id)}" data-category="{esc(category)}" '
+        'data-destination-type="x">Xで共有</a>'
+        '<span class="share-status" aria-live="polite"></span>'
+        f'</div>{SHARE_END}'
+    )
+
+
+def patch_event_page(path: Path, event: dict[str, object], base_url: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    text = strip_block(text, SOCIAL_META_START, SOCIAL_META_END)
+    text = re.sub(r'<meta property="og:image(?::[^\"]+)?"[^>]*>\n?', "", text)
+    text = re.sub(r'<meta name="twitter:(?:card|image|image:alt)"[^>]*>\n?', "", text)
+    marker = f'<meta property="og:url" content="{esc(base_url)}/events/{esc(event["id"])}/">'
+    if marker not in text:
+        raise ValueError(f"event page canonical social marker missing: {event['id']}")
+    text = text.replace(marker, marker + "\n" + social_meta(event, base_url), 1)
+
+    text = strip_block(text, SHARE_START, SHARE_END)
+    notice = '<p class="notice">'
+    if notice not in text:
+        raise ValueError(f"event page notice marker missing: {event['id']}")
+    text = text.replace(notice, share_controls(event, base_url) + "\n" + notice, 1)
+    if 'src="../../share.js"' not in text:
+        text = text.replace("</head>", '<script src="../../share.js" defer></script>\n</head>', 1)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_share_script(root: Path) -> None:
+    script = r'''(() => {
+  const copy = async value => {
+    if (navigator.clipboard?.writeText) return navigator.clipboard.writeText(value);
+    const area = document.createElement('textarea');
+    area.value = value;
+    area.setAttribute('readonly', '');
+    area.style.position = 'fixed';
+    area.style.opacity = '0';
+    document.body.appendChild(area);
+    area.select();
+    document.execCommand('copy');
+    area.remove();
+  };
+  document.addEventListener('click', async event => {
+    const button = event.target.closest('[data-share-native]');
+    if (!button) return;
+    const url = button.dataset.shareUrl || location.href;
+    const title = button.dataset.shareTitle || document.title;
+    const status = button.parentElement?.querySelector('.share-status');
+    try {
+      if (navigator.share) {
+        await navigator.share({ title, url });
+        if (status) status.textContent = '共有しました';
+      } else {
+        await copy(url);
+        if (status) status.textContent = '共有URLをコピーしました';
+      }
+    } catch (error) {
+      if (error?.name !== 'AbortError' && status) status.textContent = '共有できませんでした';
+    }
+  });
+})();
+'''
+    (root / "share.js").write_text(script, encoding="utf-8")
+
+
+def render(events_path: Path, public_root: Path, base_url: str = BASE_URL, font_path: Path | None = None) -> dict[str, int]:
+    payload = json.loads(events_path.read_text(encoding="utf-8"))
+    generated_at = parse_time(payload.get("generated_at"))
+    if generated_at is None:
+        raise ValueError("events.json generated_at is missing or invalid")
+    rows = payload.get("events")
+    if not isinstance(rows, list):
+        raise ValueError("events.json events must be a list")
+    selected = [row for row in rows if isinstance(row, dict) and indexable(row, generated_at)]
+    selected.sort(key=lambda row: (parse_time(row.get("starts_at")) or generated_at, str(row.get("id"))))
+
+    resolved_font = resolve_font(font_path)
+    og_root = public_root / "og" / "events"
+    shutil.rmtree(og_root, ignore_errors=True)
+    og_root.mkdir(parents=True, exist_ok=True)
+    for event in selected:
+        event_id = str(event["id"])
+        page = public_root / "events" / event_id / "index.html"
+        if not page.is_file():
+            raise ValueError(f"indexable event page missing: {event_id}")
+        draw_card(event, og_root / f"{event_id}.png", resolved_font)
+        patch_event_page(page, event, base_url)
+    write_share_script(public_root)
+
+    images = list(og_root.glob("*.png"))
+    if len(images) != len(selected):
+        raise ValueError("OG image coverage mismatch")
+    return {
+        "indexable_count": len(selected),
+        "og_image_count": len(images),
+        "share_enabled_count": len(selected),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--events", type=Path, default=Path("public/events.json"))
+    parser.add_argument("--public-root", type=Path, default=Path("public"))
+    parser.add_argument("--base-url", default=BASE_URL)
+    parser.add_argument("--font", type=Path)
+    args = parser.parse_args()
+    result = render(args.events, args.public_root, args.base_url.rstrip("/"), args.font)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_social_assets.py
+++ b/scripts/render_social_assets.py
@@ -7,7 +7,6 @@ import json
 import os
 import re
 import shutil
-import textwrap
 from pathlib import Path
 from urllib.parse import urlencode
 

--- a/scripts/render_social_assets.py
+++ b/scripts/render_social_assets.py
@@ -36,7 +36,7 @@ def esc(value: object) -> str:
 
 
 def strip_block(text: str, start: str, end: str) -> str:
-    return re.sub(re.escape(start) + r".*?" + re.escape(end), "", text, flags=re.S)
+    return re.sub(re.escape(start) + r".*?" + re.escape(end) + r"\n?", "", text, flags=re.S)
 
 
 def resolve_font(explicit: Path | None = None) -> Path | None:

--- a/tests/test_social_assets.py
+++ b/tests/test_social_assets.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from PIL import Image
+
+from scripts.render_search_pages import render as render_events
+from scripts.render_social_assets import render as render_social
+
+
+def _root(tmp_path: Path) -> Path:
+    (tmp_path / "index.html").write_text(
+        '<!doctype html><html><head><style>:root{--line:#ddd;--radius:20px;--muted:#666}.eyebrow{}</style></head>'
+        '<body><a class="button" href="calendar.ics">カレンダーを購読</a><footer>footer</footer></body></html>',
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_social_cards_cover_every_indexable_event_and_patch_share_ui(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    payload = {
+        "generated_at": "2026-08-16T00:00:00Z",
+        "events": [
+            {
+                "id": "music-1",
+                "title": "Music Meetup One",
+                "canonical_name": "Music Meetup One",
+                "starts_at": "2026-08-17T12:00:00Z",
+                "category": "music",
+                "category_label": "Music and Dance",
+                "primary_action_url": "https://official.example/music-1",
+            },
+            {
+                "id": "community-1",
+                "title": "Community Meetup Two",
+                "canonical_name": "Community Meetup Two",
+                "starts_at": "2026-08-18T12:00:00Z",
+                "category": "community",
+                "category_label": "Community",
+                "primary_action_url": "https://official.example/community-1",
+            },
+            {
+                "id": "review-1",
+                "title": "Review Required",
+                "starts_at": "2026-08-19T12:00:00Z",
+                "category": "music",
+                "review_required": True,
+                "primary_action_url": "https://official.example/review",
+            },
+        ],
+    }
+    events_path = root / "events.json"
+    events_path.write_text(json.dumps(payload), encoding="utf-8")
+    base = "https://example.test/project"
+    render_events(events_path, root, base)
+
+    result = render_social(events_path, root, base)
+
+    assert result == {"indexable_count": 2, "og_image_count": 2, "share_enabled_count": 2}
+    images = sorted((root / "og/events").glob("*.png"))
+    assert [path.name for path in images] == ["community-1.png", "music-1.png"]
+    digests = []
+    for path in images:
+        with Image.open(path) as image:
+            assert image.format == "PNG"
+            assert image.size == (1200, 630)
+            assert image.mode == "RGB"
+        digests.append(hashlib.sha256(path.read_bytes()).hexdigest())
+    assert len(set(digests)) == 2
+
+    page = (root / "events/music-1/index.html").read_text(encoding="utf-8")
+    assert 'property="og:image" content="https://example.test/project/og/events/music-1.png"' in page
+    assert 'property="og:image:width" content="1200"' in page
+    assert 'property="og:image:height" content="630"' in page
+    assert 'name="twitter:card" content="summary_large_image"' in page
+    assert 'name="twitter:image" content="https://example.test/project/og/events/music-1.png"' in page
+    assert 'src="../../share.js"' in page
+    assert 'data-track="share_click"' in page
+    assert 'data-destination-type="native"' in page
+    assert 'data-destination-type="x"' in page
+    assert "utm_source=share" in page
+    assert "utm_source%3Dx" in page
+    share_block = page.split("share-controls:start", 1)[1].split("share-controls:end", 1)[0]
+    assert "https://official.example/music-1" not in share_block
+    share_js = (root / "share.js").read_text(encoding="utf-8")
+    assert "navigator.share" in share_js
+    assert "navigator.clipboard" in share_js
+
+
+def test_social_render_is_idempotent(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    payload = {
+        "generated_at": "2026-08-16T00:00:00Z",
+        "events": [
+            {
+                "id": "event-1",
+                "title": "Stable Social Card",
+                "starts_at": "2026-08-17T12:00:00Z",
+                "category": "community",
+                "category_label": "Community",
+                "primary_action_url": "https://official.example/event-1",
+            }
+        ],
+    }
+    events_path = root / "events.json"
+    events_path.write_text(json.dumps(payload), encoding="utf-8")
+    base = "https://example.test/project"
+    render_events(events_path, root, base)
+
+    render_social(events_path, root, base)
+    page_first = (root / "events/event-1/index.html").read_bytes()
+    image_first = (root / "og/events/event-1.png").read_bytes()
+
+    render_social(events_path, root, base)
+
+    assert (root / "events/event-1/index.html").read_bytes() == page_first
+    assert (root / "og/events/event-1.png").read_bytes() == image_first
+    text = (root / "events/event-1/index.html").read_text(encoding="utf-8")
+    assert text.count("social-meta:start") == 1
+    assert text.count("share-controls:start") == 1


### PR DESCRIPTION
## Goal

Implement #96 by turning every indexable event detail URL into a shareable acquisition surface for X and other mobile/desktop share targets.

## Change

- generate one deterministic 1200×630 PNG per indexable event under `public/og/events/<id>.png`
- render event name, JST start, and category from canonical data only
- use a light, clean deterministic card design; no inferred event facts
- replace event-detail OGP/Twitter media tags with the local PNG and `summary_large_image`
- add Web Share API with URL-copy fallback
- add explicit X Web Intent using the same self-hosted event detail URL
- add `utm_source=share|x`, `utm_medium=social`, `utm_campaign=event_share` only to shared landing URLs; canonical stays clean
- reuse existing `data-track` analytics as `share_click`, distinguishing `native` vs `x`
- delete/rebuild the OG directory each render so expired pages cannot leave stale images
- add idempotency and 1:1 image coverage tests

## Production contract

- GitHub Actions installs Noto Sans CJK for Japanese card text
- Pillow is the only new runtime dependency
- publish fails if OG image count != event detail count
- PNG dimensions and share/meta coverage are verified before commit

## Current X guidance

X Web Intents remain the official no-app-auth flow for opening a Post composer, including `https://x.com/intent/tweet`. X card/image guidance requires HTTPS media and supports bitmap formats such as PNG/JPEG.

Closes #96 after production projection and representative live metadata/image verification.