### PR TITLE
Add per-event iCalendar downloads to event detail pages

### DIFF
--- a/scripts/render_social_assets.py
+++ b/scripts/render_social_assets.py
@@ -7,7 +7,7 @@ import json
 import os
 import re
 import shutil
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import urlencode
 
@@ -185,7 +185,7 @@ def ical_datetime(value: object) -> str:
     parsed = parse_time(value)
     if parsed is None:
         raise ValueError("calendar date-time is missing or invalid")
-    return parsed.astimezone(datetime.UTC).strftime("%Y%m%dT%H%M%SZ")
+    return parsed.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
 
 
 def fold_ical_line(line: str) -> str:
@@ -213,7 +213,7 @@ def event_ics(event: dict[str, object], base_url: str, generated_at: datetime) -
         "CALSCALE:GREGORIAN",
         "BEGIN:VEVENT",
         f"UID:{event_id}@kafka2306.github.io",
-        f"DTSTAMP:{generated_at.astimezone(datetime.UTC).strftime('%Y%m%dT%H%M%SZ')}",
+        f"DTSTAMP:{generated_at.astimezone(UTC).strftime('%Y%m%dT%H%M%SZ')}",
         f"DTSTART:{ical_datetime(event.get('starts_at'))}",
     ]
     if event.get("ends_at"):

--- a/scripts/render_social_assets.py
+++ b/scripts/render_social_assets.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import shutil
+from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlencode
 
@@ -160,9 +161,69 @@ def share_controls(event: dict[str, object], base_url: str) -> str:
         f'<a class="action" href="{esc(intent)}" target="_blank" rel="noopener noreferrer" '
         f'data-track="share_click" data-event-id="{esc(event_id)}" data-category="{esc(category)}" '
         'data-destination-type="x">Xで共有</a>'
+        f'<a class="action" href="event.ics" download data-track="calendar_event_download" '
+        f'data-event-id="{esc(event_id)}" data-category="{esc(category)}" '
+        'data-destination-type="ics">カレンダーに追加</a>'
         '<span class="share-status" aria-live="polite"></span>'
         f'</div>{SHARE_END}'
     )
+
+
+def ical_escape(value: object) -> str:
+    return (
+        str(value or "")
+        .replace("\\", "\\\\")
+        .replace("\r\n", "\n")
+        .replace("\r", "\n")
+        .replace("\n", "\\n")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+    )
+
+
+def ical_datetime(value: object) -> str:
+    parsed = parse_time(value)
+    if parsed is None:
+        raise ValueError("calendar date-time is missing or invalid")
+    return parsed.astimezone(datetime.UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def fold_ical_line(line: str) -> str:
+    chunks: list[str] = []
+    current = ""
+    for char in line:
+        limit = 75 if not chunks else 74
+        if current and len((current + char).encode("utf-8")) > limit:
+            chunks.append(current)
+            current = char
+        else:
+            current += char
+    if current:
+        chunks.append(current)
+    return "\r\n ".join(chunks)
+
+
+def event_ics(event: dict[str, object], base_url: str, generated_at: datetime) -> bytes:
+    event_id = str(event["id"])
+    canonical = f"{base_url}/events/{event_id}/"
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//KAFKA2306//VRChat Event Calendar//JA",
+        "CALSCALE:GREGORIAN",
+        "BEGIN:VEVENT",
+        f"UID:{event_id}@kafka2306.github.io",
+        f"DTSTAMP:{generated_at.astimezone(datetime.UTC).strftime('%Y%m%dT%H%M%SZ')}",
+        f"DTSTART:{ical_datetime(event.get('starts_at'))}",
+    ]
+    if event.get("ends_at"):
+        lines.append(f"DTEND:{ical_datetime(event.get('ends_at'))}")
+    lines.append(f"SUMMARY:{ical_escape(event_title(event))}")
+    description = str(event.get("description") or "").strip()
+    if description:
+        lines.append(f"DESCRIPTION:{ical_escape(description)}")
+    lines.extend([f"URL:{canonical}", "END:VEVENT", "END:VCALENDAR"])
+    return ("\r\n".join(fold_ical_line(line) for line in lines) + "\r\n").encode("utf-8")
 
 
 def patch_event_page(path: Path, event: dict[str, object], base_url: str) -> None:
@@ -239,20 +300,26 @@ def render(events_path: Path, public_root: Path, base_url: str = BASE_URL, font_
     og_root.mkdir(parents=True, exist_ok=True)
     for event in selected:
         event_id = str(event["id"])
-        page = public_root / "events" / event_id / "index.html"
+        event_root = public_root / "events" / event_id
+        page = event_root / "index.html"
         if not page.is_file():
             raise ValueError(f"indexable event page missing: {event_id}")
         draw_card(event, og_root / f"{event_id}.png", resolved_font)
+        (event_root / "event.ics").write_bytes(event_ics(event, base_url, generated_at))
         patch_event_page(page, event, base_url)
     write_share_script(public_root)
 
     images = list(og_root.glob("*.png"))
+    calendars = list((public_root / "events").glob("*/event.ics"))
     if len(images) != len(selected):
         raise ValueError("OG image coverage mismatch")
+    if len(calendars) != len(selected):
+        raise ValueError("event calendar coverage mismatch")
     return {
         "indexable_count": len(selected),
         "og_image_count": len(images),
         "share_enabled_count": len(selected),
+        "calendar_enabled_count": len(calendars),
     }
 
 

--- a/scripts/verify_crawl_graph.py
+++ b/scripts/verify_crawl_graph.py
@@ -24,9 +24,12 @@ class AnchorParser(HTMLParser):
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         if tag != "a":
             return
-        for name, value in attrs:
-            if name == "href" and value:
-                self.hrefs.append(value)
+        attributes = dict(attrs)
+        if "download" in attributes:
+            return
+        href = attributes.get("href")
+        if href:
+            self.hrefs.append(href)
 
 
 def canonicalize(url: str) -> str:

--- a/tests/test_crawl_graph.py
+++ b/tests/test_crawl_graph.py
@@ -138,6 +138,24 @@ def test_crawl_link_render_is_idempotent(tmp_path: Path) -> None:
     assert result["orphan_count"] == 0
 
 
+def test_crawl_graph_ignores_download_links_but_not_page_links(tmp_path: Path) -> None:
+    root = _build_surface(tmp_path)
+    detail = root / "events/social-1/index.html"
+    text = detail.read_text(encoding="utf-8")
+    detail.write_text(
+        text.replace("</nav>", '<a href="event.ics" download>download</a></nav>', 1),
+        encoding="utf-8",
+    )
+    assert verify(root, "https://example.test/project")["broken_search_link_count"] == 0
+
+    detail.write_text(
+        detail.read_text(encoding="utf-8").replace(' download>download</a>', '>download</a>', 1),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="broken/non-canonical search links"):
+        verify(root, "https://example.test/project")
+
+
 def test_crawl_graph_rejects_broken_search_link(tmp_path: Path) -> None:
     root = _build_surface(tmp_path)
     index = root / "index.html"

--- a/tests/test_social_assets.py
+++ b/tests/test_social_assets.py
@@ -29,8 +29,10 @@ def test_social_cards_cover_every_indexable_event_and_patch_share_ui(tmp_path: P
                 "title": "Music Meetup One",
                 "canonical_name": "Music Meetup One",
                 "starts_at": "2026-08-17T12:00:00Z",
+                "ends_at": "2026-08-17T13:30:00Z",
                 "category": "music",
                 "category_label": "Music and Dance",
+                "description": "Meet, dance, and talk.",
                 "primary_action_url": "https://official.example/music-1",
             },
             {
@@ -59,7 +61,12 @@ def test_social_cards_cover_every_indexable_event_and_patch_share_ui(tmp_path: P
 
     result = render_social(events_path, root, base)
 
-    assert result == {"indexable_count": 2, "og_image_count": 2, "share_enabled_count": 2}
+    assert result == {
+        "indexable_count": 2,
+        "og_image_count": 2,
+        "share_enabled_count": 2,
+        "calendar_enabled_count": 2,
+    }
     images = sorted((root / "og/events").glob("*.png"))
     assert [path.name for path in images] == ["community-1.png", "music-1.png"]
     digests = []
@@ -81,6 +88,9 @@ def test_social_cards_cover_every_indexable_event_and_patch_share_ui(tmp_path: P
     assert 'data-track="share_click"' in page
     assert 'data-destination-type="native"' in page
     assert 'data-destination-type="x"' in page
+    assert 'href="event.ics"' in page
+    assert 'data-track="calendar_event_download"' in page
+    assert 'data-destination-type="ics"' in page
     assert "utm_source=share" in page
     assert "utm_source%3Dx" in page
     share_block = page.split("share-controls:start", 1)[1].split("share-controls:end", 1)[0]
@@ -88,6 +98,24 @@ def test_social_cards_cover_every_indexable_event_and_patch_share_ui(tmp_path: P
     share_js = (root / "share.js").read_text(encoding="utf-8")
     assert "navigator.share" in share_js
     assert "navigator.clipboard" in share_js
+
+    calendar = (root / "events/music-1/event.ics").read_bytes()
+    assert b"\r\n" in calendar
+    calendar_text = calendar.decode("utf-8")
+    assert "BEGIN:VCALENDAR\r\n" in calendar_text
+    assert "BEGIN:VEVENT\r\n" in calendar_text
+    assert "UID:music-1@kafka2306.github.io\r\n" in calendar_text
+    assert "DTSTAMP:20260816T000000Z\r\n" in calendar_text
+    assert "DTSTART:20260817T120000Z\r\n" in calendar_text
+    assert "DTEND:20260817T133000Z\r\n" in calendar_text
+    assert "SUMMARY:Music Meetup One\r\n" in calendar_text
+    assert "URL:https://example.test/project/events/music-1/\r\n" in calendar_text
+    assert calendar_text.endswith("END:VCALENDAR\r\n")
+
+    no_end_calendar = (root / "events/community-1/event.ics").read_text(encoding="utf-8")
+    assert "DTSTART:20260818T120000Z" in no_end_calendar
+    assert "DTEND:" not in no_end_calendar
+    assert not (root / "events/review-1/event.ics").exists()
 
 
 def test_social_render_is_idempotent(tmp_path: Path) -> None:
@@ -113,11 +141,13 @@ def test_social_render_is_idempotent(tmp_path: Path) -> None:
     render_social(events_path, root, base)
     page_first = (root / "events/event-1/index.html").read_bytes()
     image_first = (root / "og/events/event-1.png").read_bytes()
+    calendar_first = (root / "events/event-1/event.ics").read_bytes()
 
     render_social(events_path, root, base)
 
     assert (root / "events/event-1/index.html").read_bytes() == page_first
     assert (root / "og/events/event-1.png").read_bytes() == image_first
+    assert (root / "events/event-1/event.ics").read_bytes() == calendar_first
     text = (root / "events/event-1/index.html").read_text(encoding="utf-8")
     assert text.count("social-meta:start") == 1
     assert text.count("share-controls:start") == 1


### PR DESCRIPTION
Progresses #68.

Adds one concrete user-visible capability without duplicating the existing share implementation:

- generate `event.ics` beside every indexable event detail page
- add a `カレンダーに追加` action to the existing detail-page action group
- use RFC 5545 `VEVENT` fields with UTC `DTSTART`, optional `DTEND`, stable `UID`, `DTSTAMP`, summary, optional description, canonical URL, CRLF line endings, and UTF-8 line folding
- track the new action separately as `calendar_event_download`
- keep the existing site-wide `calendar.ics` subscription unchanged
- add regression coverage for event calendars, events without an end time, non-indexable events, and idempotence

No new dependency, schema, workflow, or documentation file.