### PR TITLE
Yahoo由来イベント名の START / END ノイズを除去

### DIFF
--- a/scripts/fetch_yahoo_realtime.py
+++ b/scripts/fetch_yahoo_realtime.py
@@ -33,6 +33,8 @@ STATUS_RE = re.compile(
 )
 STATUS_ID_RE = re.compile(r"\d{10,25}")
 VRCHAT_RE = re.compile(r"(?i)(?:#?vrchat|#?vrc\b)")
+YAHOO_START_MARKER_RE = re.compile(r"^\s*START(?=\s)")
+YAHOO_END_MARKER_RE = re.compile(r"(?<=\s)END\s*$")
 TEXT_KEYS = ("displayText", "full_text", "fullText", "tweetText", "text")
 URL_KEYS = ("url", "tweetUrl", "statusUrl", "permalink")
 ID_KEYS = ("id", "tweetId", "statusId", "id_str", "rest_id")
@@ -159,12 +161,19 @@ def status_url(mapping: dict[str, Any], post_id: str) -> str:
     return f"https://x.com/i/web/status/{post_id}"
 
 
+def clean_yahoo_text(text: str) -> str:
+    cleaned = unescape(text).replace("\tSTART\t", " ").replace("\tEND\t", " ")
+    cleaned = YAHOO_START_MARKER_RE.sub("", cleaned, count=1)
+    cleaned = YAHOO_END_MARKER_RE.sub("", cleaned, count=1)
+    return cleaned.strip()
+
+
 def candidate_from_mapping(mapping: dict[str, Any]) -> dict[str, Any] | None:
     text = direct_string(mapping, TEXT_KEYS)
     post_id = status_id(mapping)
     if not text or not post_id:
         return None
-    text = unescape(text).replace("\tSTART\t", "").replace("\tEND\t", "")
+    text = clean_yahoo_text(text)
     return {
         "status_id": post_id,
         "url": status_url(mapping, post_id),
@@ -290,7 +299,7 @@ def candidate_to_event(
     candidate: dict[str, Any], *, now: datetime, min_retweets: int, x_ids: set[str]
 ) -> tuple[dict[str, Any] | None, str | None]:
     post_id = str(candidate.get("status_id") or "")
-    text = str(candidate.get("text") or "").strip()
+    text = clean_yahoo_text(str(candidate.get("text") or ""))
     if not STATUS_ID_RE.fullmatch(post_id):
         return None, "invalid_status_id"
     if post_id in x_ids:
@@ -345,6 +354,17 @@ def parse_instant(value: str) -> datetime | None:
     return parsed.astimezone(UTC)
 
 
+def clean_cached_event_text(event: dict[str, Any]) -> dict[str, Any]:
+    cleaned = dict(event)
+    title = clean_yahoo_text(str(cleaned.get("title") or ""))
+    description = clean_yahoo_text(str(cleaned.get("description") or ""))
+    if title:
+        cleaned["title"] = title
+    if description:
+        cleaned["description"] = re.sub(r"\s+", " ", description).strip()
+    return cleaned
+
+
 def cached_event_is_valid(event: dict[str, Any], now: datetime) -> bool:
     start = parse_instant(str(event.get("starts_at") or ""))
     source_id = str(event.get("source_id") or "")
@@ -362,10 +382,12 @@ def cached_event_is_valid(event: dict[str, Any], now: datetime) -> bool:
 
 def merge_cache(existing: list[dict[str, Any]], fresh: list[dict[str, Any]], now: datetime) -> list[dict[str, Any]]:
     selected: dict[str, dict[str, Any]] = {}
-    for event in existing:
+    for raw_event in existing:
+        event = clean_cached_event_text(raw_event)
         if cached_event_is_valid(event, now):
             selected[str(event["source_id"])] = event
-    for event in fresh:
+    for raw_event in fresh:
+        event = clean_cached_event_text(raw_event)
         if cached_event_is_valid(event, now):
             selected[str(event["source_id"])] = event
     return sorted(selected.values(), key=lambda item: (str(item.get("starts_at")), str(item.get("title"))))

--- a/tests/test_yahoo_realtime.py
+++ b/tests/test_yahoo_realtime.py
@@ -55,6 +55,51 @@ def test_structured_parser_accepts_explicit_event_and_rejects_product_only():
     assert reason == "product_only"
 
 
+def test_yahoo_boundary_markers_are_removed_but_event_start_text_is_preserved():
+    page = structured_page(
+        [
+            {
+                "id": "5234567890123456789",
+                "displayText": (
+                    "START 2026/8/7 22:00 VRChatイベントを開催。"
+                    "OPEN 21:50 / START 22:00 END"
+                ),
+                "screenName": "host",
+                "rtCount": 5,
+                "url": "https://x.com/host/status/5234567890123456789",
+            }
+        ]
+    )
+    candidate = extract_candidates(page)[0]
+    assert candidate["text"].startswith("2026/8/7")
+    assert "START 22:00" in candidate["text"]
+    assert not candidate["text"].endswith(" END")
+
+    accepted, reason = candidate_to_event(
+        candidate, now=datetime(2026, 8, 2, tzinfo=UTC), min_retweets=3, x_ids=set()
+    )
+    assert reason is None
+    assert accepted is not None
+    assert not accepted["title"].startswith("START ")
+    assert not accepted["description"].startswith("START ")
+    assert "START 22:00" in accepted["description"]
+
+
+def test_merge_cache_cleans_legacy_yahoo_boundary_markers():
+    existing = [
+        {
+            "source_id": "yahoo:x:6234567890123456789",
+            "starts_at": "2026-08-08T12:00:00Z",
+            "title": "START cached event",
+            "description": "START 8/8 21:00 VRChatイベントを開催。参加方法はJoin END",
+        }
+    ]
+    merged = merge_cache(existing, [], datetime(2026, 8, 2, tzinfo=UTC))
+    assert len(merged) == 1
+    assert merged[0]["title"] == "cached event"
+    assert merged[0]["description"] == "8/8 21:00 VRChatイベントを開催。参加方法はJoin"
+
+
 def test_parser_requires_metrics_and_rejects_x_duplicate():
     base = {
         "status_id": "1234567890123456789",


### PR DESCRIPTION
Closes #109

## 変更
- Yahoo!リアルタイム検索由来テキストの先頭 `START` / 末尾 `END` 境界マーカーを正規化
- 候補抽出だけでなく履歴再生時の `candidate_to_event` にも適用
- 既存Yahooキャッシュを `merge_cache` で再利用する際にも title / description を修復
- 本文中の `START 22:00` は保持

## 検証
- 新規構造化候補の境界マーカー除去テスト
- 本文中 `START 22:00` 保持テスト
- 既存キャッシュの title / description 修復テスト

公開反映後の最終確認対象: https://kafka2306.github.io/cast_event_cal/