### PR TITLE
feat: finish media handoff and verify public assets

### DIFF
--- a/.github/workflows/render-search-pages.yml
+++ b/.github/workflows/render-search-pages.yml
@@ -1,4 +1,5 @@
 name: Render searchable event pages
+# Canonical pipeline: verify, publish, deploy, and production read-back.
 
 on:
   workflow_dispatch:
@@ -205,6 +206,9 @@ jobs:
           fetch "$base/events.json" > /tmp/events.json
           fetch "$base/calendar.ics" > /tmp/calendar.ics
           fetch "$base/tonight/" > /tmp/tonight.html
+          fetch "$base/use/" > /tmp/use.html
+          fetch "$base/media/poster-square.webp" > /tmp/poster-square.webp
+          fetch "$base/media/poster-portrait.webp" > /tmp/poster-portrait.webp
           grep -q 'VRChat Event Calendar' /tmp/index.html
           grep -q '<link rel="canonical" href="https://kafka2306.github.io/cast_event_cal/">' /tmp/index.html
           ! grep -q 'https://kafka2306.github.io/vrc_cast_event_calender' /tmp/index.html
@@ -216,3 +220,8 @@ jobs:
           PY
           grep -q '^BEGIN:VCALENDAR' /tmp/calendar.ics
           grep -q '今夜のVRChat' /tmp/tonight.html
+          grep -q '配布・紹介素材' /tmp/use.html
+          grep -q 'poster-square.webp' /tmp/use.html
+          grep -q '掲載・訂正' /tmp/use.html
+          test -s /tmp/poster-square.webp
+          test -s /tmp/poster-portrait.webp

--- a/scripts/render_distribution_assets.py
+++ b/scripts/render_distribution_assets.py
@@ -12,6 +12,7 @@ PUBLIC_DIR = Path("public")
 MEDIA_DIR = PUBLIC_DIR / "media"
 USE_PAGE = PUBLIC_DIR / "use" / "index.html"
 HOME_PAGE = PUBLIC_DIR / "index.html"
+ISSUES_URL = "https://github.com/KAFKA2306/cast_event_cal/issues/new"
 
 COLORS = {
     "bg": "#fbfaf7",
@@ -115,6 +116,7 @@ def render_poster(config: dict, qr_path: Path, output: Path, width: int, height:
 def render_use_page(config: dict, output: Path) -> None:
     site = html.escape(config["site_url"], quote=True)
     repo = "https://github.com/KAFKA2306/cast_event_cal"
+    issues = html.escape(ISSUES_URL, quote=True)
     posters = "\n".join(
         (
             f'<li><a href="../media/{html.escape(item["filename"], quote=True)}">'
@@ -145,14 +147,19 @@ section{{margin-top:22px;padding:22px;border:1px solid var(--line);border-radius
 <p>固定URLの画像です。差し替え時もURLは変えません。VRChatのImage Loadingでは <code>*.github.io</code> が許可ドメインで、画像の最大解像度は2048 × 2048です。</p>
 <ul>{posters}</ul>
 </section>
+<section><h2>記事・ブログで紹介する</h2>
+<p>リンク先には <code>{site}</code> を使用してください。紹介画像には <a href="../media/poster-square.webp">poster-square.webp</a> をそのまま利用できます。</p>
+<p>紹介文: VRChatの公開イベントを、日時・カテゴリ・参加方法・公式リンクから探せる公開カレンダーです。</p>
+</section>
 <section><h2>正準リンク</h2><div class="actions">
 <a class="button primary" href="{site}">Web</a>
 <a class="button" href="../events.json">JSON</a>
 <a class="button" href="../calendar.ics">ICS</a>
 <a class="button" href="{repo}">GitHub</a>
 </div></section>
-<section><h2>紹介するとき</h2>
-<p>記事・SNS・ワールド内掲示からは <code>{site}</code> をリンク先として使用してください。イベント参加前は各イベントの公式リンクで最新情報を確認してください。</p>
+<section><h2>掲載・訂正</h2>
+<p>掲載候補の追加や既存情報の訂正はGitHub Issueから送れます。確認できない情報は推測で補完しません。</p>
+<p><a class="button" href="{issues}">掲載・訂正を送る</a></p>
 </section>
 </main></body></html>
 """

--- a/tests/test_distribution_assets.py
+++ b/tests/test_distribution_assets.py
@@ -2,7 +2,14 @@ from pathlib import Path
 
 from PIL import Image
 
-from scripts.render_distribution_assets import QR_IMAGE, link_homepage, load_config, render_poster, render_use_page
+from scripts.render_distribution_assets import (
+    ISSUES_URL,
+    QR_IMAGE,
+    link_homepage,
+    load_config,
+    render_poster,
+    render_use_page,
+)
 
 
 def test_distribution_assets_render(tmp_path: Path) -> None:
@@ -24,6 +31,9 @@ def test_distribution_assets_render(tmp_path: Path) -> None:
     assert "poster-portrait.webp" in rendered
     assert "../events.json" in rendered
     assert "../calendar.ics" in rendered
+    assert "記事・ブログで紹介する" in rendered
+    assert "掲載・訂正" in rendered
+    assert ISSUES_URL in rendered
 
 
 def test_homepage_distribution_link_is_idempotent(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #113

## Changes
- extend `/use/` with a reusable article/blog introduction image and canonical link guidance
- add a direct GitHub Issue entry for event listing/corrections without adding a new form or CMS
- extend production read-back to `/use/`, `poster-square.webp`, and `poster-portrait.webp`
- cover the new handoff links in regression tests

## Scope
This reuses the poster assets implemented in #112. No new database, CMS, runtime dependency, or media-specific integration is added.