### PR TITLE
イベント件数の固定下限を削除する

### DIFF
--- a/.github/workflows/update-calendar-v2.yml
+++ b/.github/workflows/update-calendar-v2.yml
@@ -137,7 +137,8 @@ jobs:
           assert registration['latest']['yahoo_accepted_count'] == len(yahoo)
           assert registration['latest']['yahoo_rejected_count'] == len(rejected)
           assert registration['latest']['yahoo_queries_failed'] == 0
-          assert events['count'] == len(rows) and events['count'] > 555
+          assert events['count'] == len(rows)
+          assert events['count'] > 0
 
           assert duplicate_audit['schema_version'] == '1.0'
           assert duplicate_audit['policy_version'] == 'canonical-occurrence.v1'


### PR DESCRIPTION
Issue #122

## 変更
- `events['count'] > 555` という固定件数条件を削除
- `events['count'] == len(rows)` の整合性検証を維持
- 空のcalendarを成功扱いしないため `events['count'] > 0` を維持
- 既存のregistration / duplicate / ICS / ontology / source health検証は変更しない

## 理由
実データではsource取得と分類が正常でもevent件数が減る。絶対件数を品質条件にすると、正常な更新を公開できない。

## 完了条件
- exact-head CI成功
- merge後main read-back
- `Update calendar data` の実データrun成功
- 最新snapshotとproductionを確認