### PR TITLE
Fix workflow ordering and production authority

### DIFF
--- a/.github/workflows/public-api-v1.yml
+++ b/.github/workflows/public-api-v1.yml
@@ -11,11 +11,10 @@ on:
   push:
     branches: [main]
     paths:
-      - "public/events.json"
-      - "scripts/build_public_api.py"
-      - "tests/test_build_public_api.py"
-      - "scripts/audit_public_feed.py"
       - ".github/workflows/public-api-v1.yml"
+  workflow_run:
+    workflows: ["Update calendar data"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -27,10 +26,13 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || 'main' }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/.github/workflows/public-feed-integrity.yml
+++ b/.github/workflows/public-feed-integrity.yml
@@ -10,10 +10,10 @@ on:
   push:
     branches: [main]
     paths:
-      - "public/events.json"
-      - "scripts/audit_public_feed.py"
-      - "tests/test_audit_public_feed.py"
       - ".github/workflows/public-feed-integrity.yml"
+  workflow_run:
+    workflows: ["Update calendar data"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -25,11 +25,14 @@ concurrency:
 
 jobs:
   audit:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || 'main' }}
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/render-search-pages.yml
+++ b/.github/workflows/render-search-pages.yml
@@ -6,19 +6,6 @@ on:
   push:
     branches: [main]
     paths:
-      - scripts/render_search_pages.py
-      - scripts/render_category_pages.py
-      - scripts/render_series_pages.py
-      - scripts/render_social_assets.py
-      - scripts/render_internal_links.py
-      - scripts/verify_crawl_graph.py
-      - tests/test_search_pages.py
-      - tests/test_category_pages.py
-      - tests/test_series_pages.py
-      - tests/test_social_assets.py
-      - tests/test_crawl_graph.py
-      - public/category-ontology.json
-      - pyproject.toml
       - .github/workflows/render-search-pages.yml
   pull_request:
     paths:

--- a/.github/workflows/update-calendar-v2.yml
+++ b/.github/workflows/update-calendar-v2.yml
@@ -69,6 +69,33 @@ jobs:
           VRCEVE_DATA_USE_APPROVED: ${{ secrets.VRCEVE_DATA_USE_APPROVED }}
           VRCEVE_ICS_URL: ${{ secrets.VRCEVE_ICS_URL }}
         run: python scripts/fetch_external_calendars.py
+      - name: Gate collection health before build
+        run: |
+          python - <<'PY'
+          from scripts.validate_update_snapshot import (
+              OPTIONAL_COLLECTION_SOURCES,
+              ROOT,
+              require,
+              sync_collection_health,
+          )
+
+          health = sync_collection_health(ROOT)
+          statuses = {
+              str(row.get('name')): str(row.get('status'))
+              for row in health.get('sources', [])
+              if isinstance(row, dict)
+          }
+          require(
+              statuses.get('yahoo_realtime_events') == 'ok',
+              f"Yahoo collection is not healthy: {statuses.get('yahoo_realtime_events')}",
+          )
+          for name in OPTIONAL_COLLECTION_SOURCES:
+              require(
+                  statuses.get(name) in {'ok', 'degraded', 'skipped'},
+                  f"optional collection source has invalid status: {name}={statuses.get(name)}",
+              )
+          print(f"collection health gate passed: {health.get('status')}")
+          PY
       - name: Build normalized calendar
         run: cast-event-cal run --strict
       - name: Enrich official X Web and WebP assets
@@ -85,6 +112,8 @@ jobs:
         run: python scripts/render_distribution_assets.py
       - name: Build registration count audit
         run: python scripts/build_registration_count_audit.py
+      - name: Audit canonical public feed
+        run: python scripts/audit_public_feed.py public/events.json --report /tmp/public-feed-audit.json
       - name: Validate generated data and collection health
         run: python scripts/validate_update_snapshot.py
       - name: Commit generated data safely

--- a/.github/workflows/yahoo-best-1000.yml
+++ b/.github/workflows/yahoo-best-1000.yml
@@ -114,7 +114,7 @@ jobs:
             data/yahoo-best-1000-raw.json
             data/yahoo-best-1000-events.json
           retention-days: 30
-      - name: Commit empirical result and production ledger
+      - name: Commit benchmark evidence only
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           set -euo pipefail
@@ -122,12 +122,6 @@ jobs:
             data/yahoo-best-1000-raw.json
             data/yahoo-best-1000-events.json
             public/yahoo-best-1000-audit.json
-            data/yahoo_realtime_events.json
-            data/yahoo_realtime_rejected.json
-            data/yahoo_realtime_health.json
-            public/yahoo-candidate-history.json
-            public/yahoo-classifier-audit.json
-            public/yahoo-positive-vocabulary.json
           )
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/yahoo-query-ablation.yml
+++ b/.github/workflows/yahoo-query-ablation.yml
@@ -101,4 +101,4 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run update-calendar-v2.yml --ref main
+        run: gh workflow run render-search-pages.yml --ref main


### PR DESCRIPTION
## Summary
- gate collector health immediately after collection, before normalization/enrichment
- audit the canonical public feed before committing the production snapshot
- make `Update calendar data` the normal upstream authority for search-page publication, Public API, and public-feed integrity
- stop Yahoo best-1000 benchmark runs from committing production Yahoo ledger files
- redeploy ablation evidence without triggering a second full production collection

## Intended order
`collect -> collection-health gate -> normalize/enrich/dedupe/render -> public-feed audit -> full snapshot validation -> commit -> workflow_run consumers -> deploy/read-back`

## Authority changes
- production Yahoo ledger: `Update calendar data` only
- benchmark workflow: benchmark evidence only
- search publication: normal path is `workflow_run` after successful production update
- Public API/feed audit: normal path is `workflow_run` after successful production update
