### PR TITLE
Serialize production follow-up workflows

### DIFF
--- a/.github/workflows/render-search-pages.yml
+++ b/.github/workflows/render-search-pages.yml
@@ -3,10 +3,6 @@ name: Render searchable event pages
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - .github/workflows/render-search-pages.yml
   pull_request:
     paths:
       - scripts/render_search_pages.py
@@ -28,7 +24,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('search-pr-{0}', github.event.pull_request.number) || 'cast-event-calendar-production' }}
+  group: ${{ github.event_name == 'pull_request' && format('search-pr-{0}', github.event.pull_request.number) || 'cast-event-calendar-publication' }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/update-calendar-v2.yml
+++ b/.github/workflows/update-calendar-v2.yml
@@ -19,6 +19,7 @@ on:
       - requirements.txt
       - pyproject.toml
       - .github/workflows/update-calendar-v2.yml
+      - .github/workflows/render-search-pages.yml
 
 permissions:
   contents: write

--- a/.github/workflows/yahoo-query-ablation.yml
+++ b/.github/workflows/yahoo-query-ablation.yml
@@ -3,7 +3,7 @@ name: Yahoo query ablation
 on:
   workflow_dispatch:
   schedule:
-    - cron: '47 20 * * *'
+    - cron: '10 21 * * *'
   pull_request:
     paths:
       - config/yahoo_query_ablation.json
@@ -98,7 +98,7 @@ jobs:
             git push origin HEAD:main
           fi
       - name: Redeploy production Pages with evidence
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run render-search-pages.yml --ref main


### PR DESCRIPTION
## Why
Production verification after #126 exposed a GitHub Actions concurrency edge case: a pending `Update calendar data` run was cancelled when another run entered the shared cross-workflow concurrency group.

## Fix
- remove main `push` ingress from searchable-page publication; automatic publication is post-update via `workflow_run`
- separate publication concurrency (`cast-event-calendar-publication`) from production collection (`cast-event-calendar-production`)
- route changes to the search workflow itself through `Update calendar data`
- move scheduled Yahoo ablation from 05:47 JST to 06:10 JST, beyond the update workflow's 35-minute timeout window
- only dispatch an ablation evidence redeploy for scheduled/manual ablation runs, never for a main push

## Required production order
`Update calendar data -> workflow_run consumers -> search publish/deploy/read-back`
