### PR TITLE
Reorder home view by user decision value

### DIFF
--- a/.github/workflows/update-calendar-v2.yml
+++ b/.github/workflows/update-calendar-v2.yml
@@ -109,6 +109,8 @@ jobs:
         run: python scripts/deduplicate_occurrences.py
       - name: Render linked-image frontend and live ontologies
         run: python scripts/render_frontend.py
+      - name: Order home view by user decision value
+        run: python scripts/reorder_home_view.py
       - name: Render Unity distribution assets
         run: python scripts/render_distribution_assets.py
       - name: Build registration count audit

--- a/scripts/reorder_home_view.py
+++ b/scripts/reorder_home_view.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+OUTPUT = Path("public/index.html")
+VIEW_ORDER_MARKER = 'data-view-order="decision-first-v1"'
+
+
+def _replace_once(html: str, old: str, new: str, error: str) -> str:
+    if old not in html:
+        raise ValueError(error)
+    return html.replace(old, new, 1)
+
+
+def reorder_home_view(html: str) -> str:
+    """Move decision-making UI ahead of operational summary information."""
+    if VIEW_ORDER_MARKER in html:
+        return html
+
+    html = _replace_once(
+        html,
+        '<main class="shell">',
+        f'<main class="shell" {VIEW_ORDER_MARKER}>',
+        "home shell marker missing",
+    )
+    html = _replace_once(
+        html,
+        '<a class="button primary" href="#agenda">今週のイベントを見る</a>',
+        '<a class="button primary" href="tonight/">今夜のイベントを見る</a>',
+        "primary home action marker missing",
+    )
+    html = _replace_once(
+        html,
+        '<section class="controls" aria-label="イベント絞り込み">',
+        '<section id="event-filters" class="controls" aria-label="イベント絞り込み">',
+        "home filter marker missing",
+    )
+
+    summary_start = html.find('<section class="summary" aria-label="集計">')
+    if summary_start < 0:
+        raise ValueError("home summary marker missing")
+    summary_end = html.find("</section>", summary_start)
+    if summary_end < 0:
+        raise ValueError("home summary closing marker missing")
+    summary_end += len("</section>")
+    summary = html[summary_start:summary_end].replace('aria-label="集計"', 'aria-label="全体集計"', 1)
+    html = html[:summary_start] + html[summary_end:]
+
+    footer_start = html.find("<footer>")
+    if footer_start < 0:
+        raise ValueError("home footer marker missing")
+    html = html[:footer_start] + summary + "\n" + html[footer_start:]
+
+    ordered_markers = (
+        '<section class="hero">',
+        '<section id="event-filters" class="controls"',
+        '<section id="recommendations"',
+        '<div class="statusbar">',
+        '<div id="agenda"',
+        '<section class="summary" aria-label="全体集計">',
+        "<footer>",
+    )
+    positions = [html.find(marker) for marker in ordered_markers]
+    if any(position < 0 for position in positions):
+        raise ValueError(f"home view marker missing after reorder: {positions}")
+    if positions != sorted(positions):
+        raise ValueError(f"home view order invalid: {positions}")
+    return html
+
+
+def main() -> int:
+    html = OUTPUT.read_text(encoding="utf-8")
+    reordered = reorder_home_view(html)
+    OUTPUT.write_text(reordered, encoding="utf-8")
+    print("reordered public/index.html by user decision value")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_home_view_order.py
+++ b/tests/test_home_view_order.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from scripts.render_frontend import patch_frontend
+from scripts.reorder_home_view import reorder_home_view
+
+
+TEMPLATE = Path("web/index.template.html")
+
+
+def rendered_home() -> str:
+    return reorder_home_view(patch_frontend(TEMPLATE.read_text(encoding="utf-8")))
+
+
+def test_home_prioritizes_decision_ui_before_operational_summary() -> None:
+    html = rendered_home()
+    markers = [
+        '<section class="hero">',
+        '<section id="event-filters" class="controls"',
+        '<section id="recommendations"',
+        '<div class="statusbar">',
+        '<div id="agenda"',
+        '<section class="summary" aria-label="全体集計">',
+        "<footer>",
+    ]
+    positions = [html.index(marker) for marker in markers]
+    assert positions == sorted(positions)
+
+
+def test_home_primary_action_is_tonight_and_subscription_remains_available() -> None:
+    html = rendered_home()
+    assert '<a class="button primary" href="tonight/">今夜のイベントを見る</a>' in html
+    assert '<a class="button" href="calendar.ics">カレンダーを購読</a>' in html
+    assert 'data-view-order="decision-first-v1"' in html
+
+
+def test_home_reorder_is_idempotent() -> None:
+    html = rendered_home()
+    assert reorder_home_view(html) == html


### PR DESCRIPTION
## Why
The home page currently puts aggregate/system information ahead of the user's primary job: deciding which VRChat event to join next.

## New information order
`Hero -> filters -> recommendations -> event agenda -> aggregate metrics -> evidence/footer`

## Changes
- change the primary CTA from the generic weekly list to the dedicated Tonight view
- move aggregate metrics below the event agenda
- keep search/filter controls immediately after the hero to avoid layout shift from async recommendations
- preserve local-first recommendations, calendar subscription, health/evidence, and all existing event-card semantics
- add a fail-loudly home-order transform and regression tests for the required section order

## User-value rationale
1. decide intent / narrow choices
2. get personalized or near-term suggestions
3. inspect concrete events
4. only then inspect overall corpus/system metrics and evidence
