### PR TITLE
Prioritize participation in event cards

### DIFF
--- a/scripts/reorder_home_view.py
+++ b/scripts/reorder_home_view.py
@@ -3,7 +3,38 @@ from __future__ import annotations
 from pathlib import Path
 
 OUTPUT = Path("public/index.html")
-VIEW_ORDER_MARKER = 'data-view-order="decision-first-v1"'
+VIEW_ORDER_MARKER = 'data-view-order="decision-first-v2"'
+LEGACY_VIEW_ORDER_MARKER = 'data-view-order="decision-first-v1"'
+CARD_ORDER_MARKER = 'data-card-order="decision-first-v1"'
+
+CARD_CSS = """
+.event{grid-template-columns:92px minmax(0,1fr)}
+.event h2{margin:0 0 8px;font-size:1.12rem}
+.event-top{margin:0 0 10px}
+.decision-row{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:10px;align-items:stretch;margin:10px 0}
+.participation{min-width:0;padding:10px 12px;border-radius:14px;background:rgba(183,219,200,.22);color:#39566a;font-size:.82rem;line-height:1.55}
+.participation b{display:block;margin-bottom:2px;color:#52627a;font-size:.68rem}
+.event-primary-action{min-width:150px;align-self:stretch;padding-inline:16px}
+.decision-meta{margin-bottom:10px}
+.event-media-link{margin-top:10px;margin-bottom:10px}
+.provenance{margin-top:10px;color:var(--muted);font-size:.72rem;line-height:1.5}
+.event-secondary-links{display:flex;gap:7px;flex-wrap:wrap;margin-top:10px}
+.event-secondary-links .event-link{background:#fff}
+.recommendation-card .event-link{margin-top:10px;align-self:flex-start}
+@media(max-width:920px){.event{grid-template-columns:76px minmax(0,1fr)}}
+@media(max-width:680px){.decision-row{grid-template-columns:1fr}.event-primary-action{width:100%;min-width:0}}
+@media(max-width:480px){.event{grid-template-columns:1fr}}
+""".strip()
+
+CARD_JS = r"""
+function participationHtml(event){const method=String(event.participation_method||'').trim();return method?`<div class="participation"><b>参加方法</b><span>${esc(method)}</span></div>`:''}
+function primaryActionHtml(event){const link=eventLinks(event)[0];return link?`<a class="event-link primary event-primary-action" href="${esc(link.url)}" target="_blank" rel="noopener noreferrer"${historyAttr(event)}>${esc(link.label)}</a>`:''}
+function secondaryActionsHtml(event){const rows=eventLinks(event).slice(1);return rows.length?`<div class="event-secondary-links">${rows.map(link=>`<a class="event-link" href="${esc(link.url)}" target="_blank" rel="noopener noreferrer"${historyAttr(event)}>${esc(link.label)}</a>`).join('')}</div>`:''}
+function detailsHtml(event){const evidence=(event.category_evidence||[]).slice(0,2).map(value=>String(value).replace(/^keyword:[^:]+:/,'')).join(' / ');const rows=[['開催形式',event.event_format],['対象',event.audience],['分類根拠',evidence]].filter(([,value])=>value);return rows.length?`<div class="details">${rows.map(([key,value])=>`<div class="detail"><b>${esc(key)}</b>${esc(value)}</div>`).join('')}</div>`:''}
+function eventHtml(event){const category=categoryKey(event.category),end=event.ends_at?`–${timeLabel(event.ends_at)}`:'',tags=(event.tags||[]).slice(0,7).map(tag=>`<span class="tag">${esc(tag)}</span>`).join(''),detail=event.category_detail?detailLabels[event.category_detail]||event.category_detail:null,mode=modeLabels[event.event_mode]||event.event_mode,confidence=Number(event.category_confidence),metaParts=[event.organizer?`主催 ${esc(event.organizer)}`:'',event.location?esc(event.location):''].filter(Boolean).join(' · ');const classes=['event',confidence&&confidence<.6?'low-confidence':'',event.event_mode==='offline'?'offline':''].filter(Boolean).join(' ');return `<article class="${classes}"><div class="time">${timeLabel(event.starts_at)}<small>${esc(end)}</small></div><div class="event-main"><h2>${esc(event.canonical_name||event.title)}</h2><div class="event-top"><span class="badge ${esc(category)}">${esc(categoryLabel(event))}</span>${detail?`<span class="badge">${esc(detail)}</span>`:''}${mode?`<span class="badge mode ${event.event_mode==='offline'?'offline':''}">${esc(mode)}</span>`:''}${event.ontology_id?'<span class="badge">辞書照合済み</span>':''}${confidence?`<span class="badge mode">分類 ${Math.round(confidence*100)}%</span>`:''}</div><div class="decision-row">${participationHtml(event)}${primaryActionHtml(event)}</div>${metaParts?`<div class="meta decision-meta">${metaParts}</div>`:''}${mediaHtml(event)}${event.description?`<p class="description">${esc(event.description)}</p>`:''}${detailsHtml(event)}${event.source?`<div class="provenance">出典 ${esc(event.source)}</div>`:''}${secondaryActionsHtml(event)}${assetProofHtml(event)}${tags?`<div class="tags">${tags}</div>`:''}</div></article>`}
+""".strip()
+
+RECOMMENDATION_JS = r"""function recommendationHtml(row){const e=row.event,link=eventLinks(e)[0],tags=(e.tags||[]).filter(tag=>!STOP_TAGS.has(normalize(tag))).slice(0,3).map(tag=>`<span class="tag">${esc(tag)}</span>`).join('');return `<article class="recommendation-card"><h3>${esc(eventTitle(e))}</h3><div class="event-top"><span class="badge ${esc(categoryKey(e.category))}">${esc(categoryLabel(e))}</span><span class="badge">${esc(dayLabel(e.starts_at))} ${esc(timeLabel(e.starts_at))}</span></div><div class="meta">${e.organizer?`主催 ${esc(e.organizer)} · `:''}${esc(e.location||'VRChat')}</div><p class="recommendation-reason">${esc(row.reason)}</p><a class="event-link primary" href="${esc(link.url)}" target="_blank" rel="noopener noreferrer"${historyAttr(e)}>${esc(link.label)}</a>${tags?`<div class="tags">${tags}</div>`:''}</article>`}"""
 
 
 def _replace_once(html: str, old: str, new: str, error: str) -> str:
@@ -12,8 +43,19 @@ def _replace_once(html: str, old: str, new: str, error: str) -> str:
     return html.replace(old, new, 1)
 
 
-def reorder_home_view(html: str) -> str:
-    """Move decision-making UI ahead of operational summary information."""
+def _replace_block(html: str, start_marker: str, end_marker: str, replacement: str, error: str) -> str:
+    start = html.find(start_marker)
+    if start < 0:
+        raise ValueError(f"{error}: start marker missing")
+    end = html.find(end_marker, start)
+    if end < 0:
+        raise ValueError(f"{error}: end marker missing")
+    return html[:start] + replacement.rstrip() + "\n" + html[end:]
+
+
+def _apply_home_order(html: str) -> str:
+    if LEGACY_VIEW_ORDER_MARKER in html:
+        return html.replace(LEGACY_VIEW_ORDER_MARKER, VIEW_ORDER_MARKER, 1)
     if VIEW_ORDER_MARKER in html:
         return html
 
@@ -49,7 +91,44 @@ def reorder_home_view(html: str) -> str:
     footer_start = html.find("<footer>")
     if footer_start < 0:
         raise ValueError("home footer marker missing")
-    html = html[:footer_start] + summary + "\n" + html[footer_start:]
+    return html[:footer_start] + summary + "\n" + html[footer_start:]
+
+
+def _apply_card_order(html: str) -> str:
+    if CARD_ORDER_MARKER in html:
+        return html
+
+    html = _replace_once(
+        html,
+        VIEW_ORDER_MARKER,
+        f"{VIEW_ORDER_MARKER} {CARD_ORDER_MARKER}",
+        "view-order marker missing before card reorder",
+    )
+    html = _replace_once(html, "</style>", f"{CARD_CSS}\n</style>", "frontend style marker missing")
+    html = _replace_block(
+        html,
+        "function recommendationHtml(row){",
+        "function renderHistorySummary(){",
+        RECOMMENDATION_JS,
+        "recommendation card function",
+    )
+    html = _replace_block(
+        html,
+        "function detailsHtml(event){",
+        "function renderAgenda(){",
+        CARD_JS,
+        "event card function block",
+    )
+    return html
+
+
+def reorder_home_view(html: str) -> str:
+    """Apply decision-first information order to the home view and event cards."""
+    if VIEW_ORDER_MARKER in html and CARD_ORDER_MARKER in html:
+        return html
+
+    html = _apply_home_order(html)
+    html = _apply_card_order(html)
 
     ordered_markers = (
         '<section class="hero">',

--- a/tests/test_home_view_order.py
+++ b/tests/test_home_view_order.py
@@ -30,7 +30,57 @@ def test_home_primary_action_is_tonight_and_subscription_remains_available() -> 
     html = rendered_home()
     assert '<a class="button primary" href="tonight/">今夜のイベントを見る</a>' in html
     assert '<a class="button" href="calendar.ics">カレンダーを購読</a>' in html
-    assert 'data-view-order="decision-first-v1"' in html
+    assert 'data-view-order="decision-first-v2"' in html
+    assert 'data-card-order="decision-first-v1"' in html
+
+
+def test_event_card_puts_participation_and_primary_action_before_media_and_evidence() -> None:
+    html = rendered_home()
+    start = html.index("function eventHtml(event){")
+    end = html.index("function renderAgenda(){", start)
+    card = html[start:end]
+
+    markers = [
+        '<div class="time">',
+        "<h2>",
+        '<div class="event-top">',
+        "${participationHtml(event)}${primaryActionHtml(event)}",
+        'class="meta decision-meta"',
+        "${mediaHtml(event)}",
+        'class="description"',
+        "${detailsHtml(event)}",
+        'class="provenance"',
+        "${secondaryActionsHtml(event)}",
+        "${assetProofHtml(event)}",
+        '<div class="tags">',
+    ]
+    positions = [card.index(marker) for marker in markers]
+    assert positions == sorted(positions)
+
+
+def test_participation_method_is_elevated_not_duplicated_in_detail_grid() -> None:
+    html = rendered_home()
+    participation_start = html.index("function participationHtml(event){")
+    details_start = html.index("function detailsHtml(event){")
+    event_start = html.index("function eventHtml(event){")
+    participation = html[participation_start:details_start]
+    details = html[details_start:event_start]
+
+    assert "event.participation_method" in participation
+    assert "参加方法" in participation
+    assert "event.participation_method" not in details
+    assert "['参加方法'" not in details
+
+
+def test_recommendation_card_shows_action_before_tags() -> None:
+    html = rendered_home()
+    start = html.index("function recommendationHtml(row){")
+    end = html.index("function renderHistorySummary(){", start)
+    card = html[start:end]
+
+    assert card.index("<h3>") < card.index('<div class="event-top">')
+    assert card.index("recommendation-reason") < card.index("event-link primary")
+    assert card.index("event-link primary") < card.index('<div class="tags">')
 
 
 def test_home_reorder_is_idempotent() -> None:


### PR DESCRIPTION
## Why
The agenda cards still reflected data richness more than the user's primary decision: whether and how to join the event. On mobile, the primary action appeared after image, description, detail fields, tags, and evidence.

## New card order
`time -> title -> category/mode -> participation + primary action -> organizer/location -> image -> description -> details -> provenance/secondary/evidence -> tags`

## Changes
- extend the existing decision-first view transform instead of adding another UI authority
- move the event title ahead of category badges
- elevate `participation_method` and the primary official action directly below title/category
- move media below decision-critical information
- reduce the detail grid to format/audience/classification evidence so participation is not duplicated
- move source, secondary links, asset evidence, and tags to the lower-information-priority area
- move recommendation primary actions ahead of tags
- lock the information order and idempotence with regression tests

## Preserved
- canonical event data and source authority
- official-link selection/deduplication
- local-only click-history recommendations
- asset provenance and secondary official links
- existing production pipeline and publication authority
