### PR TITLE
Collapse operational evidence in event cards

### DIFF
--- a/scripts/reorder_home_view.py
+++ b/scripts/reorder_home_view.py
@@ -5,7 +5,7 @@ from pathlib import Path
 OUTPUT = Path("public/index.html")
 VIEW_ORDER_MARKER = 'data-view-order="decision-first-v2"'
 LEGACY_VIEW_ORDER_MARKER = 'data-view-order="decision-first-v1"'
-CARD_ORDER_MARKER = 'data-card-order="decision-first-v1"'
+CARD_ORDER_MARKER = 'data-card-order="decision-first-v2"'
 
 CARD_CSS = """
 .event{grid-template-columns:92px minmax(0,1fr)}
@@ -17,9 +17,13 @@ CARD_CSS = """
 .event-primary-action{min-width:150px;align-self:stretch;padding-inline:16px}
 .decision-meta{margin-bottom:10px}
 .event-media-link{margin-top:10px;margin-bottom:10px}
-.provenance{margin-top:10px;color:var(--muted);font-size:.72rem;line-height:1.5}
-.event-secondary-links{display:flex;gap:7px;flex-wrap:wrap;margin-top:10px}
+.event-evidence{margin-top:12px;padding-top:9px;border-top:1px solid var(--line)}
+.event-evidence summary{width:max-content;max-width:100%;cursor:pointer;color:var(--muted);font-size:.74rem;font-weight:750;line-height:1.5}
+.event-evidence-body{margin-top:8px;padding:10px 11px;border-radius:12px;background:#f7f8fb;color:var(--muted);font-size:.72rem;line-height:1.55}
+.evidence-line{overflow-wrap:anywhere}
+.event-secondary-links{display:flex;gap:7px;flex-wrap:wrap;margin-top:8px}
 .event-secondary-links .event-link{background:#fff}
+.event-evidence .asset-proof{margin-top:8px}
 .recommendation-card .event-link{margin-top:10px;align-self:flex-start}
 @media(max-width:920px){.event{grid-template-columns:76px minmax(0,1fr)}}
 @media(max-width:680px){.decision-row{grid-template-columns:1fr}.event-primary-action{width:100%;min-width:0}}
@@ -30,8 +34,10 @@ CARD_JS = r"""
 function participationHtml(event){const method=String(event.participation_method||'').trim();return method?`<div class="participation"><b>参加方法</b><span>${esc(method)}</span></div>`:''}
 function primaryActionHtml(event){const link=eventLinks(event)[0];return link?`<a class="event-link primary event-primary-action" href="${esc(link.url)}" target="_blank" rel="noopener noreferrer"${historyAttr(event)}>${esc(link.label)}</a>`:''}
 function secondaryActionsHtml(event){const rows=eventLinks(event).slice(1);return rows.length?`<div class="event-secondary-links">${rows.map(link=>`<a class="event-link" href="${esc(link.url)}" target="_blank" rel="noopener noreferrer"${historyAttr(event)}>${esc(link.label)}</a>`).join('')}</div>`:''}
-function detailsHtml(event){const evidence=(event.category_evidence||[]).slice(0,2).map(value=>String(value).replace(/^keyword:[^:]+:/,'')).join(' / ');const rows=[['開催形式',event.event_format],['対象',event.audience],['分類根拠',evidence]].filter(([,value])=>value);return rows.length?`<div class="details">${rows.map(([key,value])=>`<div class="detail"><b>${esc(key)}</b>${esc(value)}</div>`).join('')}</div>`:''}
-function eventHtml(event){const category=categoryKey(event.category),end=event.ends_at?`–${timeLabel(event.ends_at)}`:'',tags=(event.tags||[]).slice(0,7).map(tag=>`<span class="tag">${esc(tag)}</span>`).join(''),detail=event.category_detail?detailLabels[event.category_detail]||event.category_detail:null,mode=modeLabels[event.event_mode]||event.event_mode,confidence=Number(event.category_confidence),metaParts=[event.organizer?`主催 ${esc(event.organizer)}`:'',event.location?esc(event.location):''].filter(Boolean).join(' · ');const classes=['event',confidence&&confidence<.6?'low-confidence':'',event.event_mode==='offline'?'offline':''].filter(Boolean).join(' ');return `<article class="${classes}"><div class="time">${timeLabel(event.starts_at)}<small>${esc(end)}</small></div><div class="event-main"><h2>${esc(event.canonical_name||event.title)}</h2><div class="event-top"><span class="badge ${esc(category)}">${esc(categoryLabel(event))}</span>${detail?`<span class="badge">${esc(detail)}</span>`:''}${mode?`<span class="badge mode ${event.event_mode==='offline'?'offline':''}">${esc(mode)}</span>`:''}${event.ontology_id?'<span class="badge">辞書照合済み</span>':''}${confidence?`<span class="badge mode">分類 ${Math.round(confidence*100)}%</span>`:''}</div><div class="decision-row">${participationHtml(event)}${primaryActionHtml(event)}</div>${metaParts?`<div class="meta decision-meta">${metaParts}</div>`:''}${mediaHtml(event)}${event.description?`<p class="description">${esc(event.description)}</p>`:''}${detailsHtml(event)}${event.source?`<div class="provenance">出典 ${esc(event.source)}</div>`:''}${secondaryActionsHtml(event)}${assetProofHtml(event)}${tags?`<div class="tags">${tags}</div>`:''}</div></article>`}
+function detailsHtml(event){const rows=[['開催形式',event.event_format],['対象',event.audience]].filter(([,value])=>value);return rows.length?`<div class="details">${rows.map(([key,value])=>`<div class="detail"><b>${esc(key)}</b>${esc(value)}</div>`).join('')}</div>`:''}
+function classificationEvidenceHtml(event){const rows=[],confidence=Number(event.category_confidence),evidence=(event.category_evidence||[]).slice(0,2).map(value=>String(value).replace(/^keyword:[^:]+:/,'')).join(' / ');if(event.ontology_id)rows.push('<div class="evidence-line">カテゴリ辞書照合済み</div>');if(Number.isFinite(confidence)&&confidence>0)rows.push(`<div class="evidence-line">分類信頼度 ${Math.round(confidence*100)}%</div>`);if(evidence)rows.push(`<div class="evidence-line">分類根拠 ${esc(evidence)}</div>`);return rows.join('')}
+function evidenceHtml(event){const source=event.source?`<div class="evidence-line">出典 ${esc(event.source)}</div>`:'',classification=classificationEvidenceHtml(event),secondary=secondaryActionsHtml(event),assets=assetProofHtml(event);return source||classification||secondary||assets?`<details class="event-evidence"><summary>出典・確認情報</summary><div class="event-evidence-body">${source}${classification}${secondary}${assets}</div></details>`:''}
+function eventHtml(event){const category=categoryKey(event.category),end=event.ends_at?`–${timeLabel(event.ends_at)}`:'',tags=(event.tags||[]).slice(0,3).map(tag=>`<span class="tag">${esc(tag)}</span>`).join(''),detail=event.category_detail?detailLabels[event.category_detail]||event.category_detail:null,mode=modeLabels[event.event_mode]||event.event_mode,metaParts=[event.organizer?`主催 ${esc(event.organizer)}`:'',event.location?esc(event.location):''].filter(Boolean).join(' · ');const classes=['event',event.event_mode==='offline'?'offline':''].filter(Boolean).join(' ');return `<article class="${classes}"><div class="time">${timeLabel(event.starts_at)}<small>${esc(end)}</small></div><div class="event-main"><h2>${esc(event.canonical_name||event.title)}</h2><div class="event-top"><span class="badge ${esc(category)}">${esc(categoryLabel(event))}</span>${detail?`<span class="badge">${esc(detail)}</span>`:''}${mode?`<span class="badge mode ${event.event_mode==='offline'?'offline':''}">${esc(mode)}</span>`:''}</div><div class="decision-row">${participationHtml(event)}${primaryActionHtml(event)}</div>${metaParts?`<div class="meta decision-meta">${metaParts}</div>`:''}${mediaHtml(event)}${event.description?`<p class="description">${esc(event.description)}</p>`:''}${detailsHtml(event)}${tags?`<div class="tags">${tags}</div>`:''}${evidenceHtml(event)}</div></article>`}
 """.strip()
 
 RECOMMENDATION_JS = r"""function recommendationHtml(row){const e=row.event,link=eventLinks(e)[0],tags=(e.tags||[]).filter(tag=>!STOP_TAGS.has(normalize(tag))).slice(0,3).map(tag=>`<span class="tag">${esc(tag)}</span>`).join('');return `<article class="recommendation-card"><h3>${esc(eventTitle(e))}</h3><div class="event-top"><span class="badge ${esc(categoryKey(e.category))}">${esc(categoryLabel(e))}</span><span class="badge">${esc(dayLabel(e.starts_at))} ${esc(timeLabel(e.starts_at))}</span></div><div class="meta">${e.organizer?`主催 ${esc(e.organizer)} · `:''}${esc(e.location||'VRChat')}</div><p class="recommendation-reason">${esc(row.reason)}</p><a class="event-link primary" href="${esc(link.url)}" target="_blank" rel="noopener noreferrer"${historyAttr(e)}>${esc(link.label)}</a>${tags?`<div class="tags">${tags}</div>`:''}</article>`}"""
@@ -123,7 +129,7 @@ def _apply_card_order(html: str) -> str:
 
 
 def reorder_home_view(html: str) -> str:
-    """Apply decision-first information order to the home view and event cards."""
+    """Apply decision-first information order and progressive evidence disclosure."""
     if VIEW_ORDER_MARKER in html and CARD_ORDER_MARKER in html:
         return html
 

--- a/tests/test_home_view_order.py
+++ b/tests/test_home_view_order.py
@@ -31,10 +31,10 @@ def test_home_primary_action_is_tonight_and_subscription_remains_available() -> 
     assert '<a class="button primary" href="tonight/">今夜のイベントを見る</a>' in html
     assert '<a class="button" href="calendar.ics">カレンダーを購読</a>' in html
     assert 'data-view-order="decision-first-v2"' in html
-    assert 'data-card-order="decision-first-v1"' in html
+    assert 'data-card-order="decision-first-v2"' in html
 
 
-def test_event_card_puts_participation_and_primary_action_before_media_and_evidence() -> None:
+def test_event_card_keeps_decision_information_above_optional_evidence() -> None:
     html = rendered_home()
     start = html.index("function eventHtml(event){")
     end = html.index("function renderAgenda(){", start)
@@ -49,27 +49,64 @@ def test_event_card_puts_participation_and_primary_action_before_media_and_evide
         "${mediaHtml(event)}",
         'class="description"',
         "${detailsHtml(event)}",
-        'class="provenance"',
-        "${secondaryActionsHtml(event)}",
-        "${assetProofHtml(event)}",
         '<div class="tags">',
+        "${evidenceHtml(event)}",
     ]
     positions = [card.index(marker) for marker in markers]
     assert positions == sorted(positions)
 
 
-def test_participation_method_is_elevated_not_duplicated_in_detail_grid() -> None:
+def test_operational_classification_metadata_is_not_always_visible() -> None:
     html = rendered_home()
-    participation_start = html.index("function participationHtml(event){")
-    details_start = html.index("function detailsHtml(event){")
     event_start = html.index("function eventHtml(event){")
-    participation = html[participation_start:details_start]
-    details = html[details_start:event_start]
+    event_end = html.index("function renderAgenda(){", event_start)
+    event_card = html[event_start:event_end]
 
-    assert "event.participation_method" in participation
-    assert "参加方法" in participation
+    assert "辞書照合済み" not in event_card
+    assert "分類信頼度" not in event_card
+    assert "分類根拠" not in event_card
+    assert "event.ontology_id" not in event_card
+    assert "event.category_confidence" not in event_card
+
+
+def test_participation_and_classification_evidence_are_not_duplicated_in_details() -> None:
+    html = rendered_home()
+    details_start = html.index("function detailsHtml(event){")
+    classification_start = html.index("function classificationEvidenceHtml(event){")
+    details = html[details_start:classification_start]
+
     assert "event.participation_method" not in details
     assert "['参加方法'" not in details
+    assert "event.category_evidence" not in details
+    assert "分類根拠" not in details
+    assert "開催形式" in details
+    assert "対象" in details
+
+
+def test_evidence_disclosure_preserves_provenance_and_classification_audit() -> None:
+    html = rendered_home()
+    classification_start = html.index("function classificationEvidenceHtml(event){")
+    event_start = html.index("function eventHtml(event){")
+    evidence = html[classification_start:event_start]
+
+    assert "event.category_evidence" in evidence
+    assert "event.category_confidence" in evidence
+    assert "event.ontology_id" in evidence
+    assert "分類信頼度" in evidence
+    assert "分類根拠" in evidence
+    assert "出典・確認情報" in evidence
+    assert "event.source" in evidence
+    assert "secondaryActionsHtml(event)" in evidence
+    assert "assetProofHtml(event)" in evidence
+    assert '<details class="event-evidence">' in evidence
+
+
+def test_visible_event_tags_are_capped_at_three() -> None:
+    html = rendered_home()
+    event_start = html.index("function eventHtml(event){")
+    event_end = html.index("function renderAgenda(){", event_start)
+    event_card = html[event_start:event_end]
+    assert "(event.tags||[]).slice(0,3)" in event_card
 
 
 def test_recommendation_card_shows_action_before_tags() -> None:


### PR DESCRIPTION
## Why
The event-card order is now decision-first, but the card surface still exposes operational classification metadata and provenance with the same visual availability as participation information. That increases scanning cost for ordinary users.

## New disclosure model
Always visible:
`time -> title -> category/detail/mode -> participation + primary action -> organizer/location -> media -> description -> format/audience -> up to 3 tags`

Collapsed under `出典・確認情報`:
- source/provenance
- ontology match status
- classification confidence
- classification evidence
- secondary official links
- asset provenance links

## Changes
- keep participation and primary official action in the decision-critical area
- remove `辞書照合済み` and classification confidence from visible badges
- remove classification evidence from the visible detail grid
- cap visible event tags at 3
- preserve audit metadata through a native `<details>` disclosure
- keep source authority, secondary official links, and asset proof intact inside the disclosure
- add regression tests for progressive disclosure, visible-card simplicity, evidence preservation, tag cap, and idempotence

## Preserved
- canonical event data
- official-link selection/deduplication
- recommendation behavior
- collection/build/publication authority
- evidence availability for users who need verification
