### PR TITLE
CI: production refresh は current main から開始する

### DIFF
--- a/.github/workflows/update-calendar-v2.yml
+++ b/.github/workflows/update-calendar-v2.yml
@@ -35,6 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
PR #131 の production refresh で、直前の定期runが main を更新した後も trigger時点の古いSHAをcheckoutしたため、生成物commitの rebase が全面衝突しました。

修正中に canonical search publish が main を進めたため、この古いbaseのPRは採用せず閉じます。current main をbaseにした後継PRへ置き換えます。