### PR TITLE
CI: production refresh は current main から開始する

### DIFF
--- a/.github/workflows/update-calendar-v2.yml
+++ b/.github/workflows/update-calendar-v2.yml
@@ -35,6 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
PR #131 の production refresh で、直前の定期runが main を更新した後も trigger時点の古いSHAをcheckoutしたため、生成物commitの rebase が全面衝突しました。

`Update calendar data` は concurrency で直列化されているため、job開始時点の current `main` を明示checkoutします。これにより、待ち行列の前runが main を更新しても、その更新を含むcanonical stateから再生成します。

新しいfallbackや別authorityは追加しません。今回の Pages UI を canonical public snapshot へ到達させる production blocker の再発防止です。